### PR TITLE
Sticks and Stones overrides Update README.MD

### DIFF
--- a/docs/hosting-a-server-with-northstar/dedicated-server/README.md
+++ b/docs/hosting-a-server-with-northstar/dedicated-server/README.md
@@ -95,6 +95,18 @@ Example: `+setplaylistvaroverrides "run_epilogue 0 featured_mode_amped_tacticals
 | `player_bleedout_firstAidHealPercent`        |                 |               |                                                                                                |
 | `player_bleedout_aiBleedingPlayerMissChance` |                 |               |                                                                                                |
 
+### Sticks and Stones playlist overrides
+
+| PlaylistOverrides for SNS                    | Accepted Values | Default Value | Description                                                                                    |
+| -------------------------------------------- | --------------- | ------------- | ---------------------------------------------------------------------------------------------- |
+| sns_softball_enabled                       | 0-1           | 0           | Enables Softball usage                                                                        |
+| sns_softball_kill_value                    | int           | 10          |                                                                                                |
+| sns_wme_kill_value                         | int           | 10          |                                                                                                |
+| sns_offhand_kill_value                     | int           | 10          |                                                                                                |
+| sns_reset_kill_value                       | int           | 5           |                                                                                                |
+| sns_melee_kill_value                       | int           | 5           |                                                                                                |
+| sns_reset_pulse_blade_cooldown_on_pulse_blade_kill | 0-1   | 1           | Enables getting Pulse Blade back after a Pulse Blade kill                                 |
+
 ## Convars
 
 Convars are located inside the `R2Northstar\mods\Northstar.CustomServers\mod\cfg\autoexec_ns_server.cfg` file.


### PR DESCRIPTION
Adds Sticks and Stones playlist overrides under Playlist overrides to Dedicated server hosting README.md for more dedicated server hosting options.

<!-- 
BEFORE OPENING A PULL REQUEST:
-> Check which version of Northstar your change targets. Documentation about feature not yet released should be merged into the `next-release` branch instead
-> If you're adding multiple independent changes (e.g. adding a section about modding while also fixing a typo on another page) it's generally recommended to split these changes into separate pull requests.

Note that pull requests containing lots of unhelpful commit messages will generally be squashed to keep commit history clean.
-->