### PR TITLE
Fix link to legacy guide, minor adjustment to DEP section

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,6 +20,7 @@
   * [Commands](installing-northstar/using-northstar/commands.md)
   * [Launch arguments](installing-northstar/using-northstar/launch-arguments.md)
   * [Playing on Linux](installing-northstar/using-northstar/playing-on-linux.md)
+  * [Legacy Linux Guide for 1.9.1 and older](installing-northstar/using-northstar/playing-on-linux-legacy-guide.md)
 * [FAQ](faq.md)
 
 ## Hosting a server with Northstar

--- a/docs/installing-northstar/using-northstar/playing-on-linux.md
+++ b/docs/installing-northstar/using-northstar/playing-on-linux.md
@@ -79,9 +79,9 @@ For more info and proposed fixes, refer to [this issue thread on Github](https:/
 
 ### Game crashes on launch with Cause: Access Violation Data Execution Prevention (DEP) at: 0x00000000
 
-**Steam/Steam Deck:** Try the latest release of [NorthstarProton](https://github.com/cyrv6737/NorthstarProton/releases/latest).
+**Steam/Steam Deck:** Ensure your installation matches the latest [install guide](#steam-and-steam-deck-northstarproton).
 
-**Lutris**: Try the latest release of [Wine-TKG](https://github.com/Frogging-Family/wine-tkg-git/releases/latest).
+**Lutris**: Ensure your installation matches the latest [install guide](#lutris-wine). If that fails, you may optionally try the latest release of [Wine-TKG](https://github.com/Frogging-Family/wine-tkg-git/releases/latest).
 
 ### Reducing stuttering
 


### PR DESCRIPTION
Fixes legacy linux guide by adding it to SUMMARY.md
Minor adjustment to DEP section to instead link to the installation instructions and not just offer a runner to use.