### PR TITLE
Make note of unsupported distros for NorthstarProton

### DIFF
--- a/docs/installing-northstar/using-northstar/playing-on-linux.md
+++ b/docs/installing-northstar/using-northstar/playing-on-linux.md
@@ -8,8 +8,7 @@ Northstar is officially supported on Linux, it uses compatibility layers like Pr
 
 On Steam Deck, complete the following in desktop mode. You may return to game mode once completed _(A mouse + keyboard plugged into the Deck are recommended for easier navigation of menus)_
 
-> **Check your GLIBC version.** NorthstarProton currently only supports version 2.33 and higher. Verify your installed version with `ldd --version`. If the installed GLIBC is older, use the [legacy guide](installing-northstar/using-northstar/playing-on-linux-legacy-guide.md#blank-console).
-
+> **Check your GLIBC version.** NorthstarProton currently only supports version 2.33 and higher. Verify your installed version with `ldd --version`. If the installed GLIBC is older, use the [legacy guide](playing-on-linux-legacy-guide.md). **Ubuntu 20.04 LTS**, **Debian 11**, and **Void Linux** are known to have outdated GLIBC packages.
 
 1. Make sure you ran the vanilla version of Titanfall2 at least once on Linux!
 2. Install the latest version of Northstar using [Viper](../northstar-installers.md#0negal-viper) or do it manually


### PR DESCRIPTION
Ubuntu 20.04 LTS, Debian 11, and Void Linux are known to have outdated GLIBC packages.
