### PR TITLE
Minor improvements in manual install section

### DIFF
--- a/docs/installing-northstar/manual-installation.md
+++ b/docs/installing-northstar/manual-installation.md
@@ -2,6 +2,8 @@
 
 ## Installing Northstar:
 
+If you are on Linux, please use the [guide here instead](../steamdeck-and-linux/installing-on-steamdeck-and-linux.md)
+
 {% embed url="https://www.youtube.com/watch?v=bK4pV-AHOHM" %}
 
 Firstly, note that the Northstar client is only available on PC and requires you to **both own the game and have it installed**.
@@ -9,7 +11,7 @@ Firstly, note that the Northstar client is only available on PC and requires you
 1. Download the latest version of Northstar from the [releases](https://github.com/R2Northstar/Northstar/releases) page
 2. Copy all the files in the newly downloaded zip folder to your `Titanfall2` folder.\
    ![Drag and drop the contents of the zip into your Titanfall2 folder](../images/manual-install-drag-drop-files.png)\
-   The location of the `Titanfall2` folder can vary depending on whether you purchased the game off Steam or Origin, and if you set a custom folder for game installs.
+   The location of the `Titanfall2` folder can vary depending on whether you purchased the game off Steam, Origin, or EA App, and if you set a custom folder for game installs.
    * **For Steam** - Right click _Titanfall 2_ > Open _Properties_ > Click _Local Files_ > Click _Browse_\
      Usually: `C:\Program Files (x86)\Steam\steamapps\common\Titanfall2`
    * **For Origin** - To find the location of your Origin library go to _Origin_ -> _Application Settings_ -> _Installs & Saves_ -> _On your Computer_ -> _Game Library Location_\
@@ -17,9 +19,9 @@ Firstly, note that the Northstar client is only available on PC and requires you
      Usually: `C:\Program Files (x86)\Origin Games\Titanfall2`
    * **For EA App** - To find the location of your EA library go to _Settings_ -> _Download_\
      Go to the directory under "Install location" using File Explorer and open the `Titanfall2` folder.\
-     ⚠️ The default location `C:\Program Files\EA Games\Titanfall2` is not writeable by non-admin processes. If you installed Titanfall2 in the default location using EA App, please move the install to a different location.
+     ⚠️ The default location `C:\Program Files\EA Games\Titanfall2` is not writeable by non-admin processes. If you installed Titanfall2 in the default location using EA App, please move the install to a different location and change the install directory to the new location.
 3. Launch `NorthstarLauncher.exe` to start Northstar
-   * After launching for the first time, you'll be greeted with a popup requesting to authenticate to the master server. Click _Yes_ (This can be changed in the mods menu later if desired)\
+   * After launching for the first time, you'll be greeted with a popup requesting to authenticate to the master server. Click _Yes_ (This can be changed in the mods menu later if desired or if you accidentally selected _No_) to agree.\
      ![Authentication Agreement](../images/titleagreement.png)
 4. Select _Launch Northstar_\
    ![Launch Northstar](../images/titlelaunchnorthstar.png)

--- a/docs/installing-northstar/manual-installation.md
+++ b/docs/installing-northstar/manual-installation.md
@@ -1,9 +1,6 @@
 # Manual installation
 
 ## Installing Northstar:
-
-If you are on Linux, please use the [guide here instead](../steamdeck-and-linux/installing-on-steamdeck-and-linux.md)
-
 {% embed url="https://www.youtube.com/watch?v=bK4pV-AHOHM" %}
 
 Firstly, note that the Northstar client is only available on PC and requires you to **both own the game and have it installed**.


### PR DESCRIPTION
Gave manual-installation a minor facelift and added a link at the start of the page to send Linux users to the right spot.

For the time being, I've left the Origin content alone, though we should consider dropping it and changing some errors to reflect EA App since Origin probably won't be around much longer, since EA has already replaced the original installer in every game, and scrubbed anything Origin related off its website.