### PR TITLE
Remove empty line from Northstar Installers Functions table

### DIFF
--- a/docs/installing-northstar/northstar-installers.md
+++ b/docs/installing-northstar/northstar-installers.md
@@ -12,7 +12,6 @@ Each of these installers covers a different use case. Use the table below to fin
 | Launch Vanilla                  | ✔️   | ✔️    | ✔️   | ❌    |
 | Install Mods from Thunderstore  | ✔️   | ✔️    | ✔️   | ✔️   |
 | Update Mods                     | ✔️   | ✔️    | ✔️   | ✔️   |
-|                                 |      |       |      |      |
 | Set launch arguments            | ❓    | ✔️    | ✔️   | ❌    |
 | Installing mods for other games | ✔️   | ❌     | ❌    | ❌    |
 | Linux support                   | ❓    | ✔️    | ❌    | ✔️   |


### PR DESCRIPTION
just something i accidentally found checking stuff out for vtol guide

this may be intentional, not entirely sure, but didn't entirely seem that way
