### PR TITLE
Improvements to VTOL and FlightCore guide 

### DIFF
--- a/docs/installing-northstar/northstar-installers/flightcore-guide.md
+++ b/docs/installing-northstar/northstar-installers/flightcore-guide.md
@@ -50,4 +50,4 @@ The *Mods* tab of Flightcore can display either mods installed locally, or a bro
 
 ![FlightCore's Settings tab](../../images/flightcore-settings.png)
 
-The *Settings* tab is the fourth and final tab of FlightCore. This tab allows you to view and choose your Titanfall2 directory (default directories can be found in the [Default Directories](../troubleshooting.md#game-location) section), select how many mods you want to see on in one page on the online browser in FlightCore, the version of FlightCore you're running, as well as a toggle to enable testing release channels.
+The *Settings* tab is the fourth and final tab of FlightCore. This tab allows you to view and choose your Titanfall2 directory (default directories can be found in the [Default Directories](../troubleshooting.md#game-location) section), select how many mods you want to see per page on the online browser in FlightCore, the version of FlightCore you're running, as well as a toggle to enable testing release channels.

--- a/docs/installing-northstar/northstar-installers/vtol-guide.md
+++ b/docs/installing-northstar/northstar-installers/vtol-guide.md
@@ -6,7 +6,7 @@ VTOL is a mod manager for installing and managing mods for the Northstar client 
 
 ![VTOL Main Window](../../images/vtol-main-window.png)
 
-__The _Main Menu_ of VTOL is where you'll probably spend most of your time.__
+**The _Main Menu_ of VTOL is where you'll probably spend most of your time.**
 
 This menu has a lot of useful information, such as the _"version of VTOL"_ you have, the _"version of Northstar"_ you have, if the Master Server is online, _"whether EA App/Origin are currently open"_, and a _"place to set your game path"_. 
 
@@ -43,7 +43,7 @@ After doing this, Northstar should automatically install. If not, the button at 
 
 ![Launching Northstar](../../images/vtol-launching-northstar.png)
 
-Assuming you've followed everything up to this point, you should be set to hit _"Launch Titanfall 2 Northstar"_ and play on Northstar's servers. If you encounter an error like a crash, Northstar will create a log file in the `titanfall2/r2northstar/logs` directory. You can look at this log yourself, or send it on the [Northstar Discord server](https://discord.com/invite/northstar) and someone can try to look at it and help you.
+Assuming you've followed everything up to this point, you should be set to hit _"Launch Titanfall 2 Northstar"_ and play on Northstar's servers. If you encounter an error like a crash, Northstar will create a log file in the `Titanfall2/R2Northstar/logs` directory. You can look at this log yourself, or send it on the [Northstar Discord server](https://discord.com/invite/northstar) and someone can try to look at it and help you.
 
 ## Additional Mods/Settings
 
@@ -56,7 +56,7 @@ To expand the smaller version of the tab list, press the button with 3 bars as s
 
 ![3 Bars](../../images/vtol-settings-expand.png)
 
-__NOTE: This guide will not be including the _"Home"_ button as a tab when describing this list. When it says the first tab, it means the first tab underneath the home button__
+**NOTE: This guide will not be including the _"Home"_ button as a tab when describing this list. When it says the first tab, it means the first tab underneath the home button**
 ## Installed Mods List
 
 ![Mods page](../../images/vtol-mods.png)

--- a/docs/installing-northstar/northstar-installers/vtol-guide.md
+++ b/docs/installing-northstar/northstar-installers/vtol-guide.md
@@ -6,13 +6,13 @@ VTOL is a mod manager for installing and managing mods for the Northstar client 
 
 ![VTOL Main Window](../../images/vtol-main-window.png)
 
-**The *Main Menu* of VTOL is where you'll probably spend most of your time.**
+**The _Main Menu_ of VTOL is where you'll probably spend most of your time.**
 
-This menu has a lot of useful information, such as the *version of VTOL* you have, the *version of Northstar* you have, if the Master Server is online, *whether EA App/Origin are currently open*, and a *place to set your game path*. 
+This menu has a lot of useful information, such as the _"version of VTOL"_ you have, the _"version of Northstar"_ you have, if the Master Server is online, _"whether EA App/Origin are currently open"_, and a _"place to set your game path"_. 
 
 ## Version Numbers
 
-You can see what *version of VTOL/Northstar* you have in the top left corner of the VTOL window.
+You can see what _"version of VTOL/Northstar"_ you have in the top left corner of the VTOL window.
 
 ![Version Numbers](../../images/vtol-version-numbers.png)
 
@@ -25,7 +25,7 @@ If you are unsure if you have EA or Origin, you have EA.
 
 ## Northstar Installation/Locate Titanfall 2 Install
 
-The final parts of the Main Menu are at the bottom, showing your game's directory with a button to Locate Titanfall 2 install, a small button next to this, and a button reading *Update +Northstar*
+The final parts of the Main Menu are at the bottom, showing your game's directory with a button to Locate Titanfall 2 install, a small button next to this, and a button reading _"Update +Northstar"_
 
 ![Installation Section](../../images/vtol-northstar-installation-info.png)
 
@@ -37,13 +37,13 @@ VTOL handles most things automatically, but it may still require minimal setup f
 
 Something you might have to do manually is locate your Titanfall 2 install. You can do this by pressing the button of the same name on VTOL, and navigating to your Titanfall 2 directory (If you're unsure of what your game path is, check out the [Default Directories](../troubleshooting.md#game-location) section)
 
-After doing this, Northstar should automatically install. If not, the button at the bottom will read *Install Northstar*. Let VTOL install Northstar, and you should be good to go. Once installed, this button will turn into the *Update +Northstar* shown in the screenshot earlier, which you can use to update without having to reinstall.
+After doing this, Northstar should automatically install. If not, the button at the bottom will read _"Install Northstar"_. Let VTOL install Northstar, and you should be good to go. Once installed, this button will turn into the _"Update +Northstar"_ shown in the screenshot earlier, which you can use to update without having to reinstall.
 
 ## Launching Northstar via VTOL
 
 ![Launching Northstar](../../images/vtol-launching-northstar.png)
 
-Assuming you've followed everything up to this point, you should be set to hit *Launch Titanfall 2 Northstar* and play on Northstar's servers. If you encounter an error like a crash, Northstar will create a log file in the `titanfall2/r2northstar/logs` directory. You can look at this log yourself, or send it on the [Northstar Discord server](https://discord.com/invite/northstar) and someone can try to look at it and help you.
+Assuming you've followed everything up to this point, you should be set to hit _"Launch Titanfall 2 Northstar"_ and play on Northstar's servers. If you encounter an error like a crash, Northstar will create a log file in the `titanfall2/r2northstar/logs` directory. You can look at this log yourself, or send it on the [Northstar Discord server](https://discord.com/invite/northstar) and someone can try to look at it and help you.
 
 ## Additional Mods/Settings
 
@@ -56,12 +56,12 @@ To expand the smaller version of the tab list, press the button with 3 bars as s
 
 ![3 Bars](../../images/vtol-settings-expand.png)
 
-**NOTE: This guide will not be including the *Home* button as a tab when describing this list. When it says the first tab, it means the first tab underneath the home button**
+**NOTE: This guide will not be including the _"Home"_ button as a tab when describing this list. When it says the first tab, it means the first tab underneath the home button**
 ## Installed Mods List
 
 ![Mods page](../../images/vtol-mods.png)
 
-The first tab of VTOL is the *Mods* tab. This is a list of your currently installed mods, with the ability to disable any of them quickly.
+The first tab of VTOL is the _"Mods"_ tab. This is a list of your currently installed mods, with the ability to disable any of them quickly.
 
 You can also right click on a specific mod to get the option to either delete it, or look at the mod's information (Mod Name, Author Name, Description, etc.)
 
@@ -72,27 +72,27 @@ You can also right click on a specific mod to get the option to either delete it
 
 ![Mods browser](../../images/vtol-mods-browser.png)
 
-VTOL has a built in-browser for searching [Northstar's Thunderstore page](https://northstar.thunderstore.io/) (the website where most Northstar mods get uploaded to), located at the second tab *Browse* on the tab list. You will see the newest uploaded mods here by default, which you can change by applying filters (Note: The sorting is by default Low-High for filters. You can change this by pressing the button with an arrow next to the filters button, making it High-Low)
+VTOL has a built in-browser for searching [Northstar's Thunderstore page](https://northstar.thunderstore.io/) (the website where most Northstar mods get uploaded to), located at the second tab _"Browse"_ on the tab list. You will see the newest uploaded mods here by default, which you can change by applying filters (Note: The sorting is by default Low-High for filters. You can change this by pressing the button with an arrow next to the filters button, making it High-Low)
 
-VTOL also has support where all you need to do is drag and drop a mod downloaded from the Thunderstore page onto the Mods tab (the second tab on the left side) to automatically install the mod.
+VTOL also has support where all you need to do is drag and drop a mod downloaded from the Thunderstore page onto the _"Mods"_ tab (the second tab on the left side) to automatically install the mod.
 
 ## Settings
 
 ![VTOL Settings](../../images/vtol-settings-tab.png)
 
-On the way bottom of the tab list, there is a button to open settings for the VTOL manager. You will want to keep most of these on default, but change them as you wish. It is normal for the *Restart_As_Admin* button to appear untoggled. This is also where you can tick *Enable_EA_APP_Usage* to make the client work better with the EA app, assuming you have it and not Origin.
+On the way bottom of the tab list, there is a button to open settings for the VTOL manager. You will want to keep most of these on default, but change them as you wish. It is normal for the _"Restart_As_Admin"_ button to appear untoggled. This is also where you can tick _"Enable_EA_APP_Usage"_ to make the client work better with the EA app, assuming you have it and not Origin.
 
 ## Skins
 
 ![Skins installation tab](../../images/vtol-skins.png)
 
-The third settings tab on VTOL is the *Skins* tab. VTOL has support for skins formatted for an older version of Northstar, normally requiring an extra tool. All you need to do is drag the folder of one of these old style skins onto the Skins screen to install it automatically.
+The third settings tab on VTOL is the _"Skins"_ tab. VTOL has support for skins formatted for an older version of Northstar, normally requiring an extra tool. All you need to do is drag the folder of one of these old style skins onto the Skins screen to install it automatically.
 
 ## Server
 
 ![Launch arguments/dedicated server tab](../../images/vtol-server.png)
 
-The fourth tab on VTOL is the *Server* tab. This section allows you to add Launch Arguments to your client or dedicated server. Note that this adds Launch Arguments to change what Northstar does when it launches, not to launch Northstar itself. A way you can do this is by adding [Launch Arguments](../troubleshooting.md#launch-opts) via the store you own the game on and launching through there.
+The fourth tab on VTOL is the _"Server"_ tab. This section allows you to add Launch Arguments to your client or dedicated server. Note that this adds Launch Arguments to change what Northstar does when it launches, not to launch Northstar itself. A way you can do this is by adding [Launch Arguments](../troubleshooting.md#launch-opts) via the store you own the game on and launching through there.
 
 For the dedicated server option, you can scroll through this tab to set many different options for a server which can be found on the Northstar Wiki's [Server Hosting Guide](../../hosting-a-server-with-northstar/basic-listen-server.md)
 
@@ -100,7 +100,7 @@ For the dedicated server option, you can scroll through this tab to set many dif
 
 ![Tools tab](../../images/vtol-tools.png)
 
-The fifth tab called *Tools* is meant to help those trying to create mods for Northsar. 
+The fifth tab called _"Tools"_ is meant to help those trying to create mods for Northsar. 
 
 ## ThunderStore Packer
 
@@ -129,4 +129,4 @@ The fourth screen lists a lot of commonly used tools by modders to help create m
 
 ![VTOL About section](../../images/vtol-about.png)
 
-The last section of the VTOL client is the 6th tab of VTOL, the *About* section. This screen shows you what VTOL can do, as well as a button to configure updates, and a button to check for updates for the VTOL client.
+The last section of the VTOL client is the 6th tab of VTOL, the _"About"_ section. This screen shows you what VTOL can do, as well as a button to configure updates, and a button to check for updates for the VTOL client.

--- a/docs/installing-northstar/northstar-installers/vtol-guide.md
+++ b/docs/installing-northstar/northstar-installers/vtol-guide.md
@@ -25,7 +25,7 @@ If you are unsure if you have EA or Origin, you have EA.
 
 ## Northstar Installation/Locate Titanfall 2 Install
 
-The final parts of the Main Menu are at the bottom, showing your game's directory with a button to Locate Titanfall 2 install, a small button next to this, and a button reading "Update +Northstar"
+The final parts of the Main Menu are at the bottom, showing your game's directory with a button to Locate Titanfall 2 install, a small button next to this, and a button reading *Update +Northstar*
 
 ![Installation Section](../../images/vtol-northstar-installation-info.png)
 
@@ -37,13 +37,13 @@ VTOL handles most things automatically, but it may still require minimal setup f
 
 Something you might have to do manually is locate your Titanfall 2 install. You can do this by pressing the button of the same name on VTOL, and navigating to your Titanfall 2 directory (If you're unsure of what your game path is, check out the [Default Directories](../troubleshooting.md#game-location) section)
 
-After doing this, Northstar should automatically install. If not, the button at the bottom will read "Install Northstar". Let VTOL install Northstar, and you should be good to go. Once installed, this button will turn into the "Update +Northstar" shown in the screenshot earlier, which you can use to update without having to reinstall.
+After doing this, Northstar should automatically install. If not, the button at the bottom will read *Install Northstar*. Let VTOL install Northstar, and you should be good to go. Once installed, this button will turn into the *Update +Northstar* shown in the screenshot earlier, which you can use to update without having to reinstall.
 
 ## Launching Northstar via VTOL
 
 ![Launching Northstar](../../images/vtol-launching-northstar.png)
 
-Assuming you've followed everything up to this point, you should be set to hit "Launch Titanfall 2 Northstar" and play on Northstar's servers. If you encounter an error like a crash, Northstar will create a log file in the "titanfall2/r2northstar/logs" directory. You can look at this log yourself, or send it on the [Northstar Discord server](https://discord.com/invite/northstar) and someone can try to look at it and help you.
+Assuming you've followed everything up to this point, you should be set to hit *Launch Titanfall 2 Northstar* and play on Northstar's servers. If you encounter an error like a crash, Northstar will create a log file in the `titanfall2/r2northstar/logs` directory. You can look at this log yourself, or send it on the [Northstar Discord server](https://discord.com/invite/northstar) and someone can try to look at it and help you.
 
 ## Additional Mods/Settings
 
@@ -56,14 +56,15 @@ To expand the smaller version of the tab list, press the button with 3 bars as s
 
 ![3 Bars](../../images/vtol-settings-expand.png)
 
-**NOTE: This guide will not be including the "Home" button as a tab when describing this list. When it says the first tab, it means the first tab underneath the home button**
+**NOTE: This guide will not be including the *Home* button as a tab when describing this list. When it says the first tab, it means the first tab underneath the home button**
 ## Installed Mods List
 
 ![Mods page](../../images/vtol-mods.png)
 
-The first tab of VTOL is the "Mods" tab. This is a list of your currently installed mods, with the ability to disable any of them quickly.
+The first tab of VTOL is the *Mods* tab. This is a list of your currently installed mods, with the ability to disable any of them quickly.
 
-You can also right click on a specific mod to get the option to either delete it, or look at the mod's information (Mod Name, Author Name, Description, etc.)\
+You can also right click on a specific mod to get the option to either delete it, or look at the mod's information (Mod Name, Author Name, Description, etc.)
+
 ![Right clicking on a mod](../../images/vtol-mods-right-click.png)
 
 
@@ -71,7 +72,7 @@ You can also right click on a specific mod to get the option to either delete it
 
 ![Mods browser](../../images/vtol-mods-browser.png)
 
-VTOL has a built in-browser for searching [Northstar's Thunderstore page](https://northstar.thunderstore.io/) (the website where most Northstar mods get uploaded to), located at the second tab "Browse" on the tab list. You will see the newest uploaded mods here by default, which you can change by applying filters (Note: The sorting is by default Low-High for filters. You can change this by pressing the button with an arrow next to the filters button, making it High-Low)
+VTOL has a built in-browser for searching [Northstar's Thunderstore page](https://northstar.thunderstore.io/) (the website where most Northstar mods get uploaded to), located at the second tab *Browse* on the tab list. You will see the newest uploaded mods here by default, which you can change by applying filters (Note: The sorting is by default Low-High for filters. You can change this by pressing the button with an arrow next to the filters button, making it High-Low)
 
 VTOL also has support where all you need to do is drag and drop a mod downloaded from the Thunderstore page onto the Mods tab (the second tab on the left side) to automatically install the mod.
 
@@ -79,19 +80,19 @@ VTOL also has support where all you need to do is drag and drop a mod downloaded
 
 ![VTOL Settings](../../images/vtol-settings-tab.png)
 
-On the way bottom of the tab list, there is a button to open settings for the VTOL manager. You will want to keep most of these on default, but change them as you wish. It is normal for the "Restart_As_Admin" button to appear untoggled. This is also where you can tick "Enable_EA_APP_Usage" to make the client work better with the EA app, assuming you have it and not Origin
+On the way bottom of the tab list, there is a button to open settings for the VTOL manager. You will want to keep most of these on default, but change them as you wish. It is normal for the *Restart_As_Admin* button to appear untoggled. This is also where you can tick *Enable_EA_APP_Usage* to make the client work better with the EA app, assuming you have it and not Origin.
 
 ## Skins
 
 ![Skins installation tab](../../images/vtol-skins.png)
 
-The third settings tab on VTOL is the "Skins" tab. VTOL has support for skins formatted for an older version of Northstar, normally requiring an extra tool. All you need to do is drag the folder of one of these old style skins onto the Skins screen to install it automatically.
+The third settings tab on VTOL is the *Skins* tab. VTOL has support for skins formatted for an older version of Northstar, normally requiring an extra tool. All you need to do is drag the folder of one of these old style skins onto the Skins screen to install it automatically.
 
 ## Server
 
 ![Launch arguments/dedicated server tab](../../images/vtol-server.png)
 
-The fourth tab on VTOL is the "Server" tab. This section allows you to add Launch Arguments to your client or dedicated server. Note that this adds Launch Arguments to change what Northstar does when it launches, not to launch Northstar itself. A way you can do this is by adding [Launch Arguments](../troubleshooting.md#launch-opts) via the store you own the game on and launching through there.
+The fourth tab on VTOL is the *Server* tab. This section allows you to add Launch Arguments to your client or dedicated server. Note that this adds Launch Arguments to change what Northstar does when it launches, not to launch Northstar itself. A way you can do this is by adding [Launch Arguments](../troubleshooting.md#launch-opts) via the store you own the game on and launching through there.
 
 For the dedicated server option, you can scroll through this tab to set many different options for a server which can be found on the Northstar Wiki's [Server Hosting Guide](../../hosting-a-server-with-northstar/basic-listen-server.md)
 
@@ -99,13 +100,13 @@ For the dedicated server option, you can scroll through this tab to set many dif
 
 ![Tools tab](../../images/vtol-tools.png)
 
-The fifth tab called "Tools" is meant to help those trying to create mods for Northsar. 
+The fifth tab called *Tools* is meant to help those trying to create mods for Northsar. 
 
 ## ThunderStore Packer
 
 ![ThunderStore packer](../../images/vtol-thunderstore-packer.png)
 
-The first screen is an area where you can locate your mod folder, and easily set up things such as the Name, Description, and Icon to be shown on the Thunderstore page when you go to upload your mod.
+The first screen is an area where you can locate a folder for a mod you've created, and easily set up things such as the Name, Description, and Icon to be shown on the Thunderstore page when you go to upload your mod.
 
 ## Skin Tool
 
@@ -128,4 +129,4 @@ The fourth screen lists a lot of commonly used tools by modders to help create m
 
 ![VTOL About section](../../images/vtol-about.png)
 
-The last section of the VTOL client is the 6th tab of VTOL, the "About" section. This screen shows you what VTOL can do, as well as a button to configure updates, and a button to check for updates for the VTOL client.
+The last section of the VTOL client is the 6th tab of VTOL, the *About* section. This screen shows you what VTOL can do, as well as a button to configure updates, and a button to check for updates for the VTOL client.

--- a/docs/installing-northstar/northstar-installers/vtol-guide.md
+++ b/docs/installing-northstar/northstar-installers/vtol-guide.md
@@ -6,7 +6,7 @@ VTOL is a mod manager for installing and managing mods for the Northstar client 
 
 ![VTOL Main Window](../../images/vtol-main-window.png)
 
-**The _Main Menu_ of VTOL is where you'll probably spend most of your time.**
+__The _Main Menu_ of VTOL is where you'll probably spend most of your time.__
 
 This menu has a lot of useful information, such as the _"version of VTOL"_ you have, the _"version of Northstar"_ you have, if the Master Server is online, _"whether EA App/Origin are currently open"_, and a _"place to set your game path"_. 
 
@@ -56,7 +56,7 @@ To expand the smaller version of the tab list, press the button with 3 bars as s
 
 ![3 Bars](../../images/vtol-settings-expand.png)
 
-**NOTE: This guide will not be including the _"Home"_ button as a tab when describing this list. When it says the first tab, it means the first tab underneath the home button**
+__NOTE: This guide will not be including the _"Home"_ button as a tab when describing this list. When it says the first tab, it means the first tab underneath the home button__
 ## Installed Mods List
 
 ![Mods page](../../images/vtol-mods.png)


### PR DESCRIPTION
Changes the quotes in the VTOL guide to be asterisks, as well as make the image for right clicking a mod display properly on gitbook.

Fixes grammar in the FlightCore guide's Settings section 