### PR TITLE
Mention rui_drawEnable in Northstar Commands

### DIFF
--- a/docs/installing-northstar/using-northstar/commands.md
+++ b/docs/installing-northstar/using-northstar/commands.md
@@ -48,6 +48,7 @@ bind "F5" "toggleconsole"
 | `ns_disallowed_tactical_replacement` | Name of optional replacement ability for disallowed tacticals                                               | ex: `"mp_ability_grapple"`                      |
 | `give mp_weapon_peacekraber`         | Gives you peacekraber                                                                                       |                                                 |
 | `r_latencyflex`                      | Enables [LatencyFleX](../../using-northstar/playing-on-linux/#latencyflex) (Linux-only, enabled by default) | `0` / `1`                                       |
+| `rui_DrawEnable`                     | Enables or disables the HUD                                                                                 | `0` / `1`                                       |
 
 ### Useful dev commands
 

--- a/docs/installing-northstar/using-northstar/commands.md
+++ b/docs/installing-northstar/using-northstar/commands.md
@@ -48,7 +48,7 @@ bind "F5" "toggleconsole"
 | `ns_disallowed_tactical_replacement` | Name of optional replacement ability for disallowed tacticals                                               | ex: `"mp_ability_grapple"`                      |
 | `give mp_weapon_peacekraber`         | Gives you peacekraber                                                                                       |                                                 |
 | `r_latencyflex`                      | Enables [LatencyFleX](../../using-northstar/playing-on-linux/#latencyflex) (Linux-only, enabled by default) | `0` / `1`                                       |
-| `rui_DrawEnable`                     | Enables or disables the HUD                                                                                 | `0` / `1`                                       |
+| `rui_drawEnable`                     | Enables or disables the HUD                                                                                 | `0` / `1`                                       |
 
 ### Useful dev commands
 


### PR DESCRIPTION
Adds a line referencing `rui_drawEnable` to the Northstar Commands section.

Resolves #105 