### PR TITLE
Add FlightCore link to Linux guide, update Viper link

### DIFF
--- a/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
+++ b/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
@@ -11,7 +11,7 @@ EA App currently displays a blank screen when using NorthstarProton, however Nor
 On Steam Deck, complete the following in desktop mode. You may return to game mode once completed _(A mouse + keyboard plugged into the Deck are recommended for easier navigation of menus)_
 
 1. Make sure you ran the vanilla version of Titanfall2 at least once on Linux!
-2. Install the latest version of Northstar using [Viper](../installing-northstar/northstar-installers.md#0negal-viper) or do it manually
+2. Install the latest version of Northstar using [FlightCore](../installing-northstar/northstar-installers#geckoeidechse-flightcore), [Viper](../installing-northstar/northstar-installers#0negal-viper), or do it manually
    1. For manual install download the latest version of Northstar from the [releases](https://github.com/R2Northstar/Northstar/releases) page
    2. Then extract all contents of the file to your Titanfall 2 folder ( Right click _Titanfall 2_ > Open _Properties_ > Click _Local Files_ > Click _Browse_ )
 3. Install NorthstarProton


### PR DESCRIPTION
Still finding links I forgot to replace lol

Also figured, might as well add FlightCore to the Linux guide as it's at the very least in a usable state