### PR TITLE
Add `SSL` error to FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -77,3 +77,7 @@ If you want to use Northstar you'll have to purchase Titanfall 2 either from Ste
 ### Q: Where is Frontier Defense?
 
 A: Frontier Defense is currently in development and will be available in a release when it's finished.
+
+### Q: I get an error message saying something about SSL 
+
+A: There is currently no solution to this sadly, and we aren't sure what causes it. If you get this error, please create a ticket about it in the Northstar Discord server.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -80,4 +80,4 @@ A: Frontier Defense is currently in development and will be available in a relea
 
 ### Q: I get an error message saying something along the lines of "SSL connect error" 
 
-A: There is currently no solution to this sadly, and we aren't sure what causes it. If you get this error, please create a ticket about it in the Northstar Discord server.
+A: We are unsure of what causes this, and are trying to figure out a solution for it. If you experience this, please reach out to us via a ticket on the Northstar Discord server to allow us to get more information on this issue

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -80,4 +80,4 @@ A: Frontier Defense is currently in development and will be available in a relea
 
 ### Q: I get an error message saying something along the lines of "SSL connect error" 
 
-A: We are unsure of what causes this, and are trying to figure out a solution for it. If you experience this, please reach out to us via a ticket on the Northstar Discord server to allow us to get more information on this issue
+A: We are unsure of what causes this, and are trying to figure out a solution for it. If you experience this, please reach out to us via a ticket on the Northstar Discord server to allow us to get more information on the issue

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -78,6 +78,6 @@ If you want to use Northstar you'll have to purchase Titanfall 2 either from Ste
 
 A: Frontier Defense is currently in development and will be available in a release when it's finished.
 
-### Q: I get an error message saying something about SSL 
+### Q: I get an error message saying something along the lines of "SSL connect error" 
 
 A: There is currently no solution to this sadly, and we aren't sure what causes it. If you get this error, please create a ticket about it in the Northstar Discord server.


### PR DESCRIPTION
The question's wording is a bit rough and I could only go off of a couple random messages about it from searching in the server. Part of the process of moving the faq discord channel to the wiki's faq page