### PR TITLE
Make FAQ section use references

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,33 +6,33 @@ description: Frequently asked questions
 
 ## **If you have any issues please go to [the troubleshooting page.](installing-northstar/troubleshooting.md)**
 
-### Q: Where are all my levels and saved loadouts?
+### Q: Where are all my levels and saved loadouts? <a href="#faq-loadouts" id="faq-loadouts"></a>
 
 A: Northstar runs separate from official servers and progress does not carry over.
 
 However your progress on official servers is not lost, so running vanilla client after playing on Northstar you should be back to your old level on official servers.
 
-### Q: I get an error message saying "Player Not Found" or "Invalid Master Server Token"
+### Q: I get an error message saying "Player Not Found" or "Invalid Master Server Token" <a href="#faq-playernotfound" id="faq-playernotfound"></a>
 
 These two errors can commonly be fixed for the average user by following the guide [here](installing-northstar/troubleshooting.md#player-not-found-invalid-master-server-token). "Invalid Master Server Token" can also be caused by the Northstar master server being offline, however this is normally not the cause of the error.
 
-### Q: How do I open the console?
+### Q: How do I open the console? <a href="#faq-devconsole" id="faq-devconsole"></a>
 
 A: Check [_Opening the console_](installing-northstar/using-northstar/commands.md#opening-the-console).
 
-### Q: How can I check if my server is listed on the server browser?
+### Q: How can I check if my server is listed on the server browser? <a href="#faq-is-my-server-listed" id="faq-is-my-server-listed"></a>
 
 You can use community-made server browsers such as: [https://taskinoz.com/northstar/](https://taskinoz.com/northstar/) or [https://cpdt.dev/northstar/](https://cpdt.dev/northstar/)
 
-### Q: Will there be a console version?
+### Q: Will there be a console version? <a href="#faq-console" id="faq-console"></a>
 
 A: No.
 
-### Q: Does AI work? What about custom maps?
+### Q: Does AI work? What about custom maps? <a href="#faq-ai" id="faq-ai"></a>
 
 A: AI does work! Custom maps however will take time. Possibly a lot of time, don't ask for an ETA.
 
-### Q: I'm trying to invite a friend via Steam/Origin but they cannot join me?
+### Q: I'm trying to invite a friend via Steam/Origin but they cannot join me? <a href="#faq-invite-friends" id="faq-invite-friends"></a>
 
 A: Due to the way Northstar works, you sadly cannot just create a private match and invite a friend via Steam/Origin. Instead you'll have to host a server.
 
@@ -48,40 +48,40 @@ and instructions to host a _listen server_:
 [basic-listen-server.md](hosting-a-server-with-northstar/basic-listen-server.md)
 {% endcontent-ref %}
 
-### Q: Can I use Northstar to play the campaign?
+### Q: Can I use Northstar to play the campaign? <a href="#faq-campaign" id="faq-campaign"></a>
 
 A: The campaign can be played using Northstar but for the best experience it is recommended to use vanilla. A [co-op campaign mod is in development](https://github.com/R2Northstar/NorthstarMods/tree/main/Northstar.Coop) and it will be made available when it is finished.
 
-### Q: I get an error saying "Showing user info for UID 0 on hardware" and can't connect to servers
+### Q: I get an error saying "Showing user info for UID 0 on hardware" and can't connect to servers <a href="#faq-UID-0" id="faq-UID-0"></a>
 
 A: Should be fixed soon.
 
-### Q: Can you host a dedicated server on Linux?
+### Q: Can you host a dedicated server on Linux? <a href="#faq-dedicated-linux" id="faq-dedicated-linux"></a>
 
 A: It works using wine and llvmpipe, a guide is WIP.
 
-### Q: I get an error message saying "Connection timed out" when trying to connect to my own dedicated server
+### Q: I get an error message saying "Connection timed out" when trying to connect to my own dedicated server <a href="#faq-connected-timed-out" id="faq-connection-timed-out"></a>
 
 A: Add `+net_usesocketsforloopback 1` in your `ns_startup_args.txt` and `ns_startup_dedi_args.txt`, restart both client and server.
 
-### Q: What's with the "r2" part in the name of some of the Northstar things?
+### Q: What's with the "r2" part in the name of some of the Northstar things? <a href="#faq-r2" id="faq-r2"></a>
 
 `r2` refers to the internal development name of Titanfall 2 given to it by Respawn. Titanfall 1 for example is `r1`, Apex Legends is `r5`, etc.\
 The reason this wiki for example is called `r2northstar.gitbook.io` is due to the fact that "_Northstar_" is a rather common name and as such often already reserved by other organisations and people. "_R2Northstar_" is both uncommon and therefore still available and ties "_Northstar_" with Titanfall 2, due to the `r2` part of the name.
 
-### Q: Can I use a pirated/cracked copy Titanfall 2 to run Northstar?
+### Q: Can I use a pirated/cracked copy Titanfall 2 to run Northstar? <a href="#faq-pirated" id="faq-pirated"></a>
 
 A: The answer is obvious, No! Northstar does not support piracy of any kind.\
 If you want to use Northstar you'll have to purchase Titanfall 2 either from Steam/Origin/EA Desktop App or use a subscription service like Gamepass PC and EA Play.
 
-### Q: Where is Frontier Defense?
+### Q: Where is Frontier Defense? <a href="#faq-frontier-defense" id="faq-frontier-defense"></a>
 
 A: Frontier Defense is currently in development and will be available in a release when it's finished.
 
-### Q: I get an error message saying something along the lines of "SSL connect error" 
+### Q: I get an error message saying something along the lines of "SSL connect error" <a href="#faq-ssl" id="faq-ssl"></a>
 
 A: We are unsure of what causes this, and are trying to figure out a solution for it. If you experience this, please reach out to us via a ticket on the Northstar Discord server to allow us to get more information on the issue
 
-### Q: Why is my game running so bad?
+### Q: Why is my game running so bad? <a href="#faq-performance" id="faq-performance"></a>
 
 A: This usually lies behind your computer's specs not being high enough in order to run the game, but can also be affected by EA App's overlay. You can disable this by going to and following the [disable EA overlay section](installing-northstar/troubleshooting.md#ea-overlay).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -69,7 +69,7 @@ A: Add `+net_usesocketsforloopback 1` in your `ns_startup_args.txt` and `ns_star
 `r2` refers to the internal development name of Titanfall 2 given to it by Respawn. Titanfall 1 for example is `r1`, Apex Legends is `r5`, etc.\
 The reason this wiki for example is called `r2northstar.gitbook.io` is due to the fact that "_Northstar_" is a rather common name and as such often already reserved by other organisations and people. "_R2Northstar_" is both uncommon and therefore still available and ties "_Northstar_" with Titanfall 2, due to the `r2` part of the name.
 
-### Q: Can I use a pirated/cracked copy Titanfall 2 to run Northstar? <a href="#faq-pirated" id="faq-pirated"></a>
+### Q: Can I use a pirated/cracked copy Titanfall 2 to run Northstar? <a href="#faq-piracy" id="faq-piracy"></a>
 
 A: The answer is obvious, No! Northstar does not support piracy of any kind.\
 If you want to use Northstar you'll have to purchase Titanfall 2 either from Steam/Origin/EA Desktop App or use a subscription service like Gamepass PC and EA Play.

--- a/docs/installing-northstar/troubleshooting.md
+++ b/docs/installing-northstar/troubleshooting.md
@@ -206,12 +206,12 @@ The current solution to this is signing out of the EA App, then _without signing
 
 If that solution doesn't work, you can try logging out of the EA App, closing all EA related proccesses (including background ones) using task manager. After this, manually reopen the EA App, log in, and try to launch Northstar again. (If you don't know how to use task manager, press `"ctrl + alt + delete"`, select Task Manager, and hit `"More Info"` on the bottom right. If you can't see more info, then you've already clicked it before and don't need to do it again. After this, when you right click on a process it will open a small pop up with`"End Task"`as an option, which is what you want to use).
 
-This error can also appear if you are pirating the game, which we neither condone nor support as stated [here](../faq.md#q-can-i-use-a-pirated-cracked-copy-titanfall-2-to-run-northstar)
+This error can also appear if you are pirating the game, which we neither condone nor support as stated [here](../faq.md#faq-piracy)
 
 ## Disable EA App overlay <a href="#ea-overlay" id="ea-overlay"></a>
 
 The purpose of disabling the EA App overlay is to increase performance, as it can be very taxing even on high end hardware. You can disable it by clicking on your profile in the top right of the EA App, clicking on the drop down arrow, going to settings, going to `Application`, then scrolling down and disabling the EA App overlay.
-This will also disable invites, however [Northstar does not use these](../faq.md#q-im-trying-to-invite-a-friend-via-steam-origin-but-they-cannot-join-me)
+This will also disable invites, however [Northstar does not use these](../faq.md#faq-invite-friends)
 
 ![Applications settings](../images/ea-application-settings.png)
 ![Toggling EA Overlay to OFF](../images/ea-overlay-disable.png)


### PR DESCRIPTION
makes sections referencing faq work on both github and gitbook instead of just on gitbook, not entirely required but figured itd be nice and make it more straightforward to those writing in the future, hopefully