### PR TITLE
Link to Linux hosting guide in FAQ section

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -58,7 +58,7 @@ A: Should be fixed soon.
 
 ### Q: Can you host a dedicated server on Linux?
 
-A: It works using wine and llvmpipe, a guide is WIP.
+A: Check the [Linux dedicated server hosting section](hosting-a-server-with-northstar/dedicated-server/hosting-on-linux.md)
 
 ### Q: I get an error message saying "Connection timed out" when trying to connect to my own dedicated server
 


### PR DESCRIPTION
Changes the "WIP" portion of dedicated server linux hosting on the FAQ to reference the relevant wiki section

boy i sure do love opening a pr minutes after my last one which will create conflicts clueless