### PR TITLE
Move `using-northstar/launch-arguments.md` to the dedicated `using-northstar` directory

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -24,7 +24,7 @@
   * [Direct Connect](using-northstar/direct-connect.md)
   * [Gamemodes](using-northstar/gamemodes.md)
   * [Commands](using-northstar/commands.md)
-  * [Launch arguments](installing-northstar/using-northstar/launch-arguments.md)
+  * [Launch arguments](using-northstar/launch-arguments.md)
   * [Advanced](using-northstar/advanced.md)
 * [FAQ](faq.md)
 

--- a/docs/using-northstar/launch-arguments.md
+++ b/docs/using-northstar/launch-arguments.md
@@ -24,4 +24,4 @@ Here's a list of command line arguments from the base game.
 # Environment Variables
 | Variable name      | Description                                                                                        | Value                            |
 | ------------------ | -------------------------------------------------------------------------------------------------- | -------------------------------- |
-| `LFX`              | Enables the use of [LatencyFleX](../../using-northstar/playing-on-linux/#latencyflex) (Linux-only) | `0` or `1`                       |
+| `LFX`              | Enables the use of [LatencyFleX](../steamdeck-and-linux/installing-on-steamdeck-and-linux#latencyflex) (Linux-only) | `0` or `1`                       |

--- a/docs/using-northstar/launch-arguments.md
+++ b/docs/using-northstar/launch-arguments.md
@@ -24,4 +24,4 @@ Here's a list of command line arguments from the base game.
 # Environment Variables
 | Variable name      | Description                                                                                        | Value                            |
 | ------------------ | -------------------------------------------------------------------------------------------------- | -------------------------------- |
-| `LFX`              | Enables the use of [LatencyFleX](../steamdeck-and-linux/installing-on-steamdeck-and-linux#latencyflex) (Linux-only) | `0` or `1`                       |
+| `LFX`              | Enables the use of [LatencyFleX](../steamdeck-and-linux/installing-on-steamdeck-and-linux.md#latencyflex) (Linux-only) | `0` or `1`                       |


### PR DESCRIPTION
Also fixes broken link to LatencyFleX instructions in `launch-arguments.md`

Closes #167