### PR TITLE
Update `player not found` sections

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,9 +12,9 @@ A: Northstar runs separate from official servers and progress does not carry ove
 
 However your progress on official servers is not lost, so running vanilla client after playing on Northstar you should be back to your old level on official servers.
 
-### Q: I get an error message saying "Player Not Found" or "Invalid Master Server Token" <a href="#faq-playernotfound" id="faq-playernotfound"></a>
+### Q: I get an error message saying "Couldn't find player account" or "Invalid Master Server Token" <a href="#faq-playernotfound" id="faq-playernotfound"></a>
 
-These two errors can commonly be fixed for the average user by following the guide [here](installing-northstar/troubleshooting.md#player-not-found-invalid-master-server-token). "Invalid Master Server Token" can also be caused by the Northstar master server being offline, however this is normally not the cause of the error.
+These two errors can commonly be fixed for the average user by following the guide [here](installing-northstar/troubleshooting.md#playeraccount). "Invalid Master Server Token" can also be caused by the Northstar master server being offline, however this is normally not the cause of the error.
 
 ### Q: I get an error message saying "Failed creating log file! Make sure the profile directory is writable."/ Why won't my mod manager install mods? <a href="#faq-failed-log" id="faq-failed-log"></a>
 

--- a/docs/installing-northstar/troubleshooting.md
+++ b/docs/installing-northstar/troubleshooting.md
@@ -204,9 +204,11 @@ This is an error commonly caused by EA not properly updating players' names when
 
 The current solution to this is signing out of the EA App, then _without signing back into the EA App_, open **Vanilla** Titanfall 2. This should prompt EA App to pop up and ask you to sign in again, sign in on that prompt. Close Vanilla Titanfall 2 and open **Northstar**, and the error should be fixed.
 
-If that solution doesn't work, you can try logging out of the EA App, closing all EA related proccesses (including background ones) using task manager. After this, manually reopen the EA App, log in, and try to launch Northstar again. (If you don't know how to use task manager, press `"ctrl + alt + delete"`, select Task Manager, and hit `"More Info"` on the bottom right. If you can't see more info, then you've already clicked it before and don't need to do it again. After this, when you right click on a process it will open a small pop up with`"End Task"`as an option, which is what you want to use).
+Another common issue that can cause this error is when Steam and EA accounts aren't properly linked (Note: this only applies if you own Titanfall 2 on Steam). To check if this is the case, you can check if you see Titanfall 2 in your library on the EA App (yes, even if you own it on Steam). If you see it, then try the other solutions again. If you don't see it, follow [EA's official guide on linking Steam and EA accounts](https://help.ea.com/en/help/pc/link-ea-and-steam/).
 
 This error can also appear if you are pirating the game, which we neither condone nor support as stated [here](../faq.md#faq-piracy)
+
+If none of the previous solutions apply, you can try logging out of the EA App, closing all EA related proccesses (including background ones) using task manager. After this, manually reopen the EA App, log in, and try to launch Northstar again. (If you don't know how to use task manager, press `"ctrl + alt + delete"`, select Task Manager, and hit `"More Info"` on the bottom right. If you can't see more info, then you've already clicked it before and don't need to do it again. After this, when you right click on a process it will open a small pop up with`"End Task"`as an option, which is what you want to use).
 
 ## Disable EA App overlay <a href="#ea-overlay" id="ea-overlay"></a>
 

--- a/docs/installing-northstar/troubleshooting.md
+++ b/docs/installing-northstar/troubleshooting.md
@@ -198,7 +198,7 @@ The following command will reset all your loadouts and levels!
 
 Open console in-game in main menu, type in `ns_resetpersistence` and press enter. Close console again and click on "Launch Northstar". All your stuff should now be reset.
 
-## Player Not Found/Invalid Master Server Token
+## Couldn't find player account/Invalid Master Server Token <a href="#playeraccount" id="playeraccount"></a>
 
 This is an error commonly caused by EA not properly updating players' names when launching Northstar, especially prevalent for people who have changed their EA username before.
 


### PR DESCRIPTION
As of https://github.com/R2Northstar/NorthstarMods/pull/598 the more "obvious" message to the user is "Couldn't find player account", so both sections in this pr are updated for this. Imo, just wasn't worth splitting the name changes but I can change it to do that if wanted

I added a section on linking accounts because that accounts for a significant portion of the player not found errors, and added a reference (as well as updated the one in FAQ) to make the link work better and more straightforward

Personally, I think the last solution involving task manager could be removed entirely (I don't think I've ever seen someone have to do that one where the sign out or link account methods haven't worked) but having more info isn't always bad