### PR TITLE
Add page for documenting packages

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,6 +20,7 @@
 
 * [Using Northstar](using-northstar/README.md)
   * [Mods](using-northstar/mods.md)
+  * [Packages](using-northstar/packages.md)
   * [Server Browser](using-northstar/server-browser.md)
   * [Direct Connect](using-northstar/direct-connect.md)
   * [Gamemodes](using-northstar/gamemodes.md)

--- a/docs/using-northstar/packages.md
+++ b/docs/using-northstar/packages.md
@@ -1,10 +1,10 @@
 # Packages
 
-Packages are community created mods with the [Thunderstore](https://northstar.thunderstore.io/) Package structure retained used for installation via Mod Managers. They are located in the `Titanfall2\R2Northstar\packages` folder and can be accessed via the `Mods` menu at the bottom of the main menu.
+Packages are community created mods with the [Thunderstore](https://northstar.thunderstore.io/) package structure retained used for installation via Mod Managers. They are located in the `Titanfall2\R2Northstar\packages` folder and can be accessed via the `Mods` menu at the bottom of the main menu.
 
 ## Manual installation
 
 1. Download a mod from Thunderstore
-2. Right click the relevant Zip and Extract All    
+2. Right click the relevant Zip and _Extract All_ \
    (Keep the suggested destination folder)
 3. Copy the output folder into `Titanfall2\R2Northstar\packages`

--- a/docs/using-northstar/packages.md
+++ b/docs/using-northstar/packages.md
@@ -1,0 +1,10 @@
+# Packages
+
+Packages are community created mods with the [Thunderstore](https://northstar.thunderstore.io/) Package structure retained used for installation via Mod Managers. They are located in the `Titanfall2\R2Northstar\packages` folder and can be accessed via the `Mods` menu at the bottom of the main menu.
+
+## Manual installation
+
+1. Download a mod from Thunderstore
+2. Right click the relevant Zip and Extract All    
+   (Keep the suggested destination folder)
+3. Copy the output folder into `Titanfall2\R2Northstar\packages`


### PR DESCRIPTION
Package docs

Includes a basic explanation of what packages are and a short guide on how to manually install packages.

Unsure if the Mod Installation in the Manual Installation section should be updated, I personally think that mods should continue to be for core mods and anything requiring human intervention. 