### PR TITLE
Slight formatting update to troubleshooting

### DIFF
--- a/docs/installing-northstar/troubleshooting.md
+++ b/docs/installing-northstar/troubleshooting.md
@@ -10,10 +10,10 @@ Also note that some solutions described below can also apply to the base game, l
 
 ![LSX Authentication Challenge failed](https://user-images.githubusercontent.com/97235072/148391447-300e1b47-6148-43f7-8854-b0882e150d12.png)
 
-If the usual workaround of restarting Origin/rebooting or running the vanilla game first and then Northstar don’t work, try the following:
+If the usual workarounds of restarting EA/Origin, rebooting your pc, or running the vanilla game first and then Northstar don’t work, try the following:
 
 * First and foremost, double check that you are _logged in_ on EA/Origin. Titanfall will _not_ run if you are not connected to EA servers first (and neither will Titanfall + Northstar).
-* Run the game with EA/Origin/Steam by adding [launch options](troubleshooting.md#launch-opts) instead of starting NorthstarLauncher.exe (important)
+* Run the game with Steam/EA/Origin by adding [launch options](troubleshooting.md#launch-opts) instead of starting NorthstarLauncher.exe (important)
 * Sign out and exit EA/Origin, then start Northstar. It will prompt you for a login, _hopefully_ fixing it if nothing else worked
 * Start normal Titanfall 2 and then Northstar (_ONLY WORKS SOMETIMES_)
 
@@ -35,13 +35,13 @@ This error is usually caused by running the `NorthstarLauncher.exe` in the wrong
 
 ![Engine Error: File corruption detected. Please repair or re-install the game.](https://user-images.githubusercontent.com/39478251/147338706-74797220-7d7f-4c81-9ba0-d88e29a2a1e2.png)
 
-Don't panic! This warning isn't as serious as it seems. It's simply an incorrect error message caused by Origin/EA App. If you get this warning after launching the game, try updating your Northstar install to the [newest release](https://github.com/R2Northstar/Northstar/releases), as this error was mostly resolved in version `v1.4.0`.
+Don't panic! This warning isn't as serious as it seems. It's simply an incorrect error message caused by EA/Origin. If you get this warning after launching the game, try updating your Northstar install to the [newest release](https://github.com/R2Northstar/Northstar/releases), as this error was mostly resolved in version `v1.4.0`.
 
 If that doesn't work, you should verify your Titanfall2 files. If you're confused on how to verify files, follow [this](troubleshooting.md#verify-files) guide.
 
 ## Failed copying wsock32.dll <a href="#wsock" id="wsock"></a>
 
-You are probably using EA Desktop app and it sets up game installations with no write permissions contrary to Origin.
+You are probably using the EA Desktop app and it sets up game installations with no write permissions contrary to EA/Origin.
 
 ### Solution 1
 
@@ -166,9 +166,9 @@ Alternative to that fix:
 
 1. Close the game
 2. Open task manager
-3. End Origin (everything origin related)
-4. Launch Origin as admin
-5. Start the game through Origin with `-northstar` in [launch options](troubleshooting.md#launch-opts)
+3. End EA/Origin (everything EA/Origin related)
+4. Launch EA/Origin as admin
+5. Start the game through Steam/EA/Origin with `-northstar` in [launch options](troubleshooting.md#launch-opts)
 6. See if that fixed it
 
 ## Could't Initialize Sound / DEVICE\_IN\_USE <a href="#initsound" id="initsound"></a>


### PR DESCRIPTION
Just to keep the format consistent, this PR updates the format of mentioning one of Steam, EA, OR Origin to say `Steam/EA/Origin`

When only EA or Origin are relevant, it says `EA/Origin` instead. Also fixes some grammar issues affecting mentions of these

Surely nobody will do something that breaks this format later on :clueless:

Also oh my god last time I name a branch after making edits on main accidentally