### PR TITLE
Add origin offline/ORIGIN_LOGGED_OUT to troubleshooting

### DIFF
--- a/docs/installing-northstar/troubleshooting.md
+++ b/docs/installing-northstar/troubleshooting.md
@@ -17,6 +17,15 @@ If the usual workarounds of restarting EA/Origin, rebooting your pc, or running 
 * Sign out and exit EA/Origin, then start Northstar. It will prompt you for a login, _hopefully_ fixing it if nothing else worked
 * Start normal Titanfall 2 and then Northstar (_ONLY WORKS SOMETIMES_)
 
+## Origin Offline/ORIGIN_LOGGED_OUT <a href="#origin-offline" id="origin-offline"></a>
+
+This error usually happens when EA doesn't properly connect/see the EA App process on your pc. Most of the time this can be fixed by:
+
+1. Making sure you're signed into the EA App and can see Titanfall in your EA Library (only applies to Steam owners. If you can't, check [EA's official guide for linking accounts](https://help.ea.com/en/help/pc/link-ea-and-steam/)
+2. Using task manager to end the `EA App` and `EA Background service` tasks, opening the EA App, then launching Northstar
+
+If you don't know how to use task manager, press `"ctrl + alt + delete"`, select Task Manager, and hit `"More Info"` on the bottom right. If you can't see more info, then you've already clicked it before and don't need to do it again. After this, when you right click on a process it will open a small pop up with `"End Task"` as an option, which is what you want to use.
+
 ## Tier0.dll Not found <a href="#tier0" id="tier0"></a>
 
 ![Failed to load the tier0.dll](../images/northstar-launcher-error-wrong-location.png)

--- a/docs/installing-northstar/troubleshooting.md
+++ b/docs/installing-northstar/troubleshooting.md
@@ -21,8 +21,8 @@ If the usual workarounds of restarting EA/Origin, rebooting your pc, or running 
 
 This error usually happens when the EA App fails to connect to EA servers properly. To fix this, you can:
 
-1. Make sure you're signed into the EA App and can see Titanfall2 in your EA Library (only applies to Steam owners. If you can't, check [EA's official guide for linking accounts](https://help.ea.com/en/help/pc/link-ea-and-steam/)
-2. Use task manager to end the `EA App` and `EA Background service` tasks, open the EA App, then launch Northstar
+1. Make sure you're signed into the EA App and can see Titanfall2 in your EA Library (only applies to Steam owners. If you can't, check [EA's official guide for linking accounts](https://help.ea.com/en/help/pc/link-ea-and-steam/).
+2. Use task manager to end the `EA App` and `EA Background service` tasks, open the EA App, then launch Northstar.
 
 ## Tier0.dll Not found <a href="#tier0" id="tier0"></a>
 

--- a/docs/installing-northstar/troubleshooting.md
+++ b/docs/installing-northstar/troubleshooting.md
@@ -21,7 +21,7 @@ If the usual workarounds of restarting EA/Origin, rebooting your pc, or running 
 
 This error usually happens when EA doesn't properly connect/see the EA App process on your pc. Most of the time this can be fixed by:
 
-1. Making sure you're signed into the EA App and can see Titanfall in your EA Library (only applies to Steam owners. If you can't, check [EA's official guide for linking accounts](https://help.ea.com/en/help/pc/link-ea-and-steam/)
+1. Making sure you're signed into the EA App and can see Titanfall2 in your EA Library (only applies to Steam owners. If you can't, check [EA's official guide for linking accounts](https://help.ea.com/en/help/pc/link-ea-and-steam/)
 2. Using task manager to end the `EA App` and `EA Background service` tasks, opening the EA App, then launching Northstar
 
 If you don't know how to use task manager, press `"ctrl + alt + delete"`, select Task Manager, and hit `"More Info"` on the bottom right. If you can't see more info, then you've already clicked it before and don't need to do it again. After this, when you right click on a process it will open a small pop up with `"End Task"` as an option, which is what you want to use.

--- a/docs/installing-northstar/troubleshooting.md
+++ b/docs/installing-northstar/troubleshooting.md
@@ -19,12 +19,10 @@ If the usual workarounds of restarting EA/Origin, rebooting your pc, or running 
 
 ## Origin Offline/ORIGIN_LOGGED_OUT <a href="#origin-offline" id="origin-offline"></a>
 
-This error usually happens when EA doesn't properly connect/see the EA App process on your pc. Most of the time this can be fixed by:
+This error usually happens when the EA App fails to connect to EA servers properly. To fix this, you can:
 
-1. Making sure you're signed into the EA App and can see Titanfall2 in your EA Library (only applies to Steam owners. If you can't, check [EA's official guide for linking accounts](https://help.ea.com/en/help/pc/link-ea-and-steam/)
-2. Using task manager to end the `EA App` and `EA Background service` tasks, opening the EA App, then launching Northstar
-
-If you don't know how to use task manager, press `"ctrl + alt + delete"`, select Task Manager, and hit `"More Info"` on the bottom right. If you can't see more info, then you've already clicked it before and don't need to do it again. After this, when you right click on a process it will open a small pop up with `"End Task"` as an option, which is what you want to use.
+1. Make sure you're signed into the EA App and can see Titanfall2 in your EA Library (only applies to Steam owners. If you can't, check [EA's official guide for linking accounts](https://help.ea.com/en/help/pc/link-ea-and-steam/)
+2. Use task manager to end the `EA App` and `EA Background service` tasks, open the EA App, then launch Northstar
 
 ## Tier0.dll Not found <a href="#tier0" id="tier0"></a>
 


### PR DESCRIPTION
i included these together because they tend to go hand in hand with solutions. sometimes origin offline is due to not being logged in and sometimes logged out is due to needing to restart the task manager process (ea service try to be coherent challenge)

request for this came from a [thread on the discord server](https://discord.com/channels/920776187884732556/1140985677937377300)