### PR TITLE
change href to match ms error token

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,7 +14,7 @@ However your progress on official servers is not lost, so running vanilla client
 
 ### Q: I get an error message saying "Couldn't find player account" or "Invalid Master Server Token" <a href="#INVALID_MASTERSERVER_TOKEN" id="INVALID_MASTERSERVER_TOKEN"></a>
 
-These two errors can commonly be fixed for the average user by following the guide [here](installing-northstar/troubleshooting.md#playeraccount). "Invalid Master Server Token" can also be caused by the Northstar master server being offline, however this is normally not the cause of the error.
+These two errors can commonly be fixed for the average user by following the guide [here](installing-northstar/troubleshooting.md#PLAYER_NOT_FOUND). "Invalid Master Server Token" can also be caused by the Northstar master server being offline, however this is normally not the cause of the error.
 
 ### Q: I get an error message saying "Failed creating log file! Make sure the profile directory is writable."/ Why won't my mod manager install mods? <a href="#faq-failed-log" id="faq-failed-log"></a>
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,7 +12,7 @@ A: Northstar runs separate from official servers and progress does not carry ove
 
 However your progress on official servers is not lost, so running vanilla client after playing on Northstar you should be back to your old level on official servers.
 
-### Q: I get an error message saying "Couldn't find player account" or "Invalid Master Server Token" <a href="#faq-playernotfound" id="faq-playernotfound"></a>
+### Q: I get an error message saying "Couldn't find player account" or "Invalid Master Server Token" <a href="#INVALID_MASTERSERVER_TOKEN" id="INVALID_MASTERSERVER_TOKEN"></a>
 
 These two errors can commonly be fixed for the average user by following the guide [here](installing-northstar/troubleshooting.md#playeraccount). "Invalid Master Server Token" can also be caused by the Northstar master server being offline, however this is normally not the cause of the error.
 

--- a/docs/installing-northstar/troubleshooting.md
+++ b/docs/installing-northstar/troubleshooting.md
@@ -198,7 +198,7 @@ The following command will reset all your loadouts and levels!
 
 Open console in-game in main menu, type in `ns_resetpersistence` and press enter. Close console again and click on "Launch Northstar". All your stuff should now be reset.
 
-## Couldn't find player account/Invalid Master Server Token <a href="#playeraccount" id="playeraccount"></a>
+## Couldn't find player account/Invalid Master Server Token <a href="#PLAYER_NOT_FOUND" id="PLAYER_NOT_FOUND"></a>
 
 This is an error commonly caused by EA not properly updating players' names when launching Northstar, especially prevalent for people who have changed their EA username before.
 


### PR DESCRIPTION
this is for https://github.com/R2Northstar/NorthstarMods/pull/648 ( and in part  https://github.com/R2Northstar/NorthstarLauncher/pull/468 ), this matches the href tag to the exact ms response so we can open the wiki section directly without hacky shenanigans 
