### PR TITLE
Remove mention of min. required Northstar version

### DIFF
--- a/docs/using-northstar/commands.md
+++ b/docs/using-northstar/commands.md
@@ -11,9 +11,6 @@ To open your console you'll either have to switch to the English (US) layout **b
 
 ### Rebinding the console
 {% hint style="info" %}
-Make sure you updated [Northstar to version v1.5.0](https://github.com/R2Northstar/Northstar/releases) or higher.
-{% endhint %}
-{% hint style="info" %}
 The console can only be bound to ```"`"``` or one of the function keys ```"F1" - "F12"```
 {% endhint %}
 


### PR DESCRIPTION
Remove mention of min. required Northstar version in regards to binding console key.

It said it would require at least version v1.5.0 of Northstar which has been released over a year ago at this point and version gate is since way higher than that, making the disclaimer pointless.
