### PR TITLE
Add missing repo links

### DIFF
--- a/docs/credits.md
+++ b/docs/credits.md
@@ -11,3 +11,8 @@ Source code contributors can be found through these links:
 - [NorthstarWiki](https://github.com/R2Northstar/NorthstarWiki/graphs/contributors)
 - [NorthstarLauncher](https://github.com/R2Northstar/NorthstarLauncher/graphs/contributors)
 - [NorthstarMasterServer](https://github.com/R2Northstar/NorthstarMasterServer/graphs/contributors)
+- [Atlas](https://github.com/R2Northstar/Atlas/graphs/contributors)
+- [ModdingDocs](https://github.com/R2Northstar/ModdingDocs)
+- [NorthstarDiscordRPC](https://github.com/R2Northstar/NorthstarDiscordRPC)
+- [NorthstarNavs](https://github.com/R2Northstar/NorthstarNavs)
+- [NorthstarStubs](https://github.com/R2Northstar/NorthstarStubs)


### PR DESCRIPTION
Some newer repos repos weren't added to this list when they were created.
This PR adds the missing repo to the list.

No clue if we should also add [tools org repos](https://github.com/R2NorthstarTools/) here...