### PR TITLE
Rename "listening server" to "quickstart"

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,7 +33,7 @@
 ## Hosting a server with Northstar
 
 * [Prerequisites](hosting-a-server-with-northstar/prerequisites.md)
-* [Hosting a Basic Listen Server](hosting-a-server-with-northstar/basic-listen-server.md)
+* [Quick start - Private match](hosting-a-server-with-northstar/quick-start.md)
 * [Hosting a Dedicated Server](hosting-a-server-with-northstar/dedicated-server/README.md)
   * [Best practices](hosting-a-server-with-northstar/dedicated-server/best-practices.md)
   * [Hosting on Linux](hosting-a-server-with-northstar/dedicated-server/hosting-on-linux.md)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -48,8 +48,8 @@ Check the prerequisites:
 
 and instructions to host a _listen server_:
 
-{% content-ref url="hosting-a-server-with-northstar/basic-listen-server.md" %}
-[basic-listen-server.md](hosting-a-server-with-northstar/basic-listen-server.md)
+{% content-ref url="hosting-a-server-with-northstar/quick-start.md" %}
+[quick-start.md](hosting-a-server-with-northstar/quick-start.md)
 {% endcontent-ref %}
 
 ### Q: Can I use Northstar to play the campaign? <a href="#faq-campaign" id="faq-campaign"></a>

--- a/docs/hosting-a-server-with-northstar/quick-start.md
+++ b/docs/hosting-a-server-with-northstar/quick-start.md
@@ -1,4 +1,13 @@
-# Hosting a Basic Listen Server
+# Quick start - Private match
+
+## Requirements
+ Port forward `37015` (UDP), and no [CGNAT](prerequisites.md#cgnat)
+
+Make sure you already installed Northstar [as described here](../installing-northstar/basic-setup.md).
+
+{% hint style="warning" %}
+This page is for hosting a quick server with friends, if you are looking for a more detailed guide go [here](./dedicated-server/README.md)
+{% endhint %}
 
 ## Instructions
 
@@ -48,8 +57,8 @@ sv_cheats 1; script GameRules_ChangeMap( "mp_forwardbase_kodai", "ctf" ); sv_che
 ```
 
 replace `mp_forwardbase_kodai` and `ctf` with your desired map and gamemode.\
-The list of maps can be found [here](server-settings/file-names.md#maps).\
-The list of gamemodes [here](server-settings/file-names.md#vanilla).
+The list of maps can be found [here](./server-settings/file-names.md#maps).\
+The list of gamemodes [here](./server-settings/file-names.md#vanilla).
 
 If someone keeps messing with the settings, set `ns_private_match_only_host_can_change_settings` to `2`, so that only you can change them.
 

--- a/docs/hosting-a-server-with-northstar/quick-start.md
+++ b/docs/hosting-a-server-with-northstar/quick-start.md
@@ -57,8 +57,8 @@ sv_cheats 1; script GameRules_ChangeMap( "mp_forwardbase_kodai", "ctf" ); sv_che
 ```
 
 replace `mp_forwardbase_kodai` and `ctf` with your desired map and gamemode.\
-The list of maps can be found [here](./server-settings/file-names.md#maps).\
-The list of gamemodes [here](./server-settings/file-names.md#vanilla).
+The list of maps can be found [here](server-settings/file-names.md#maps).\
+The list of gamemodes [here](server-settings/file-names.md#vanilla).
 
 If someone keeps messing with the settings, set `ns_private_match_only_host_can_change_settings` to `2`, so that only you can change them.
 

--- a/docs/installing-northstar/northstar-installers/vtol-guide.md
+++ b/docs/installing-northstar/northstar-installers/vtol-guide.md
@@ -94,7 +94,7 @@ The third settings tab on VTOL is the _"Skins"_ tab. VTOL has support for skins 
 
 The fourth tab on VTOL is the _"Server"_ tab. This section allows you to add Launch Arguments to your client or dedicated server. Note that this adds Launch Arguments to change what Northstar does when it launches, not to launch Northstar itself. A way you can do this is by adding [Launch Arguments](../troubleshooting.md#launch-opts) via the store you own the game on and launching through there.
 
-For the dedicated server option, you can scroll through this tab to set many different options for a server which can be found on the Northstar Wiki's [Server Hosting Guide](../../hosting-a-server-with-northstar/basic-listen-server.md)
+For the dedicated server option, you can scroll through this tab to set many different options for a server which can be found on the Northstar Wiki's [Server Hosting Guide](../../hosting-a-server-with-northstar/quick-start.md)
 
 ## Tools
 

--- a/docs/modding-and-development/development/northstarmasterserver/README.md
+++ b/docs/modding-and-development/development/northstarmasterserver/README.md
@@ -8,7 +8,7 @@ The old NodeJS master server has been replaced in favour of the Go rewrite calle
 
 The master server is responsible for centralizing game servers created by players, it also verifies that connecting players own an Origin account with Titanfall 2.
 
-There's no need to host your own master server to play games with other people, you can use [direct connect](../../../using-northstar/direct-connect.md) or just setup a [normal server](../../../hosting-a-server-with-northstar/basic-listen-server.md) that announces itself to `northstar.tf`. This tutorial is aimed for those who want to contribute improvements to the code or test their own changes to the project.
+There's no need to host your own master server to play games with other people, you can use [direct connect](../../../using-northstar/direct-connect.md) or just setup a [normal server](../../../hosting-a-server-with-northstar/quick-start.md) that announces itself to `northstar.tf`. This tutorial is aimed for those who want to contribute improvements to the code or test their own changes to the project.
 
 ## Contents
 


### PR DESCRIPTION
A new user will not understand what a listing server is and wont click on the page this might help with that ( also added a warning what the page is for )
