### PR TITLE
Mention Nvidia workaround for Proton

### DIFF
--- a/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
+++ b/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
@@ -15,6 +15,7 @@ NorthstarProton has some problems and may stop working at any point, if this hap
 On Steam Deck, complete the following in desktop mode. You may return to game mode once completed _(A mouse + keyboard plugged into the Deck are recommended for easier navigation of menus)_
 
 1. Make sure you ran the vanilla version of Titanfall2 at least once on Linux!
+   * If you use an Nvidia GPU you may need to start the game using Proton 6.3-8 for the first time
 2. Install the latest version of Northstar using [FlightCore](../installing-northstar/northstar-installers#geckoeidechse-flightcore), [Viper](../installing-northstar/northstar-installers#0negal-viper), or do it manually
    1. For manual install download the latest version of Northstar from the [releases](https://github.com/R2Northstar/Northstar/releases) page
    2. Then extract all contents of the file to your Titanfall 2 folder ( Right click _Titanfall 2_ > Open _Properties_ > Click _Local Files_ > Click _Browse_ )


### PR DESCRIPTION
On newer Nvidia Drivers NorthstarProton as well as newer Proton versions in general cause the EA App installer to crash.

Older Proton releases are not affected by this, but also don't have a lot of the performance improvements and new functionalites that come with an update to date Proton release.

An older Proton release is only needed during installation, not when playing.

AMD is not affected, unsure about Intel.

<!-- 
BEFORE OPENING A PULL REQUEST:
-> Check which version of Northstar your change targets. Documentation about feature not yet released should be merged into the `next-release` branch instead
-> If you're adding multiple independent changes (e.g. adding a section about modding while also fixing a typo on another page) it's generally recommended to split these changes into separate pull requests.

Note that pull requests containing lots of unhelpful commit messages will generally be squashed to keep commit history clean.
-->

Replace this line with a short description of your change.
