### PR TITLE
Add workflow for adding Issues to the project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,9 +4,6 @@ on:
   issues:
     types:
       - opened
-  pull_request:
-    types:
-      - opened
 
 jobs:
   add-to-project:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,20 @@
+name: add-to-project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: "https://github.com/orgs/R2Northstar/projects/3"
+          github-token: "${{ secrets.PROJECT_BOARD_TOKEN }}"
+          

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -14,4 +14,3 @@ jobs:
         with:
           project-url: "https://github.com/orgs/R2Northstar/projects/3"
           github-token: "${{ secrets.PROJECT_BOARD_TOKEN }}"
-          


### PR DESCRIPTION
Automatically adds all opened issues to the project board.

Pull requests cannot be auto-added as pull requests from forks do not have access to the token required to add new objects to the board.