### PR TITLE
Remove mention of next-release branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,5 @@
 <!-- 
 BEFORE OPENING A PULL REQUEST:
--> Check which version of Northstar your change targets. Documentation about feature not yet released should be merged into the `next-release` branch instead
 -> If you're adding multiple independent changes (e.g. adding a section about modding while also fixing a typo on another page) it's generally recommended to split these changes into separate pull requests.
 
 Note that pull requests containing lots of unhelpful commit messages will generally be squashed to keep commit history clean.


### PR DESCRIPTION
Remove mention of `next-release` branch from pull request template

`next-release` only existed while there were lots of changes still happening to wiki as everything was new. Now that the dust has settled, the preferred approach is to just hold of merging the change until the release has been made.

Given our faster release cycle and fewer wiki changes this usually doesn't inccur any issues with merge conflicts caused by other changes to wiki being merged.