### PR TITLE
Vanilla section update

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -27,6 +27,7 @@
   * [Commands](using-northstar/commands.md)
   * [Launch arguments](using-northstar/launch-arguments.md)
   * [Progression System](using-northstar/progression.md)
+  * [Vanilla via Northstar](using-northstar/vanilla.md)
   * [Advanced](using-northstar/advanced.md)
 * [FAQ](faq.md)
 

--- a/docs/installing-northstar/northstar-installers/vtol-guide.md
+++ b/docs/installing-northstar/northstar-installers/vtol-guide.md
@@ -104,7 +104,7 @@ It is normal for the _"Restart_As_Admin"_ button to appear untoggled. This is al
 The third settings tab on VTOL is the _"Skins"_ tab. VTOL has support for DDS format skins (the skins with the numbered folders in them), which are commonly used for Vanilla Titanfall 2, with Northstar generally opting to convert them to mods.
 
 This format is older and less consistent than converting them to a mod to be used with Northstar (see [Advocate](./#advocate)).
-It can still be used on Vanilla by making use of a [vanilla via Northstar](../../using-northstar/vanilla.md#vanilla-with-mods).
+It can still be used on Vanilla by playing [Vanilla via Northstar](../../using-northstar/vanilla.md#vanilla-with-mods).
 
 However, if you want you can still install skins like this for use with Northstar.
 All you need to do is drag the folder of a DDS format skin onto the Skins screen of VTOL to install it automatically.

--- a/docs/installing-northstar/northstar-installers/vtol-guide.md
+++ b/docs/installing-northstar/northstar-installers/vtol-guide.md
@@ -104,7 +104,7 @@ It is normal for the _"Restart_As_Admin"_ button to appear untoggled. This is al
 The third settings tab on VTOL is the _"Skins"_ tab. VTOL has support for DDS format skins (the skins with the numbered folders in them), which are commonly used for Vanilla Titanfall 2, with Northstar generally opting to convert them to mods.
 
 This format is older and less consistent than converting them to a mod to be used with Northstar (see [Advocate](./#advocate)).
-It can still be used on Vanilla by making use of a [vanilla profile](../../using-northstar/advanced.md#vanilla-profile).
+It can still be used on Vanilla by making use of a [vanilla via Northstar](../../using-northstar/vanilla.md#vanilla-with-mods).
 
 However, if you want you can still install skins like this for use with Northstar.
 All you need to do is drag the folder of a DDS format skin onto the Skins screen of VTOL to install it automatically.

--- a/docs/using-northstar/advanced.md
+++ b/docs/using-northstar/advanced.md
@@ -6,10 +6,10 @@ This is a section detailing the more advanced parts of using Northstar, with som
 
 ## Mod profiles <a href="#profiles" id="profiles"></a>
 
-Profiles are a way to launch a version of Northstar with specific mods enabled, differing per profile. These profiles are separated by folders that you create yourself, and add your own mods to. This is especially useful if you want to [play vanilla using Northstar](advanced.md#vanilla-on-northstar).\
+Profiles are a way to launch a version of Northstar with specific mods enabled, differing per profile. These profiles are separated by folders that you create yourself, and add your own mods to.\
 Currently, the only mod managers supporting profiles are [VTOL](https://github.com/BigSpice/VTOL) and [r2modman](https://thunderstore.io/package/ebkr/r2modman/).
 
-### Regular Profile
+### Creating a profile
 
 The first thing you want to do while creating a new profile is to have a Northstar release version downloaded and ready to be used. You will only need the `R2Northstar` folder from this second version, as the rest of the `NorthstarRelease.vX.Y.Z.zip` doesn't matter to creating additional profiles.
 
@@ -19,15 +19,7 @@ In order to create the `.bat` to launch this profile, you'll need to first creat
 
 You can set up profiles in an even more advanced way by setting up a way to use Steam to launch multiple different profiles from their newer launch menu that appears when you can launch a game in more ways than one. This is also covered [here](../installing-northstar/basic-setup.md#adding-alternate-launch-option-for-steam), and can be set up for profiles by simply adding the `-profile=PROFILE FOLDER NAME HERE` to the arguments of the new option for NorthstarLauncher, as seen below
 
-![SteamEdit using Northstar Profiles](../images/steamedit-profiles.png)
-
-### Vanilla Profile
-
-A simple "vanilla" profile can be created using a `.bat` file, without needing to fully make an additional mods folder. You can do this simply by creating a `.txt` file inside of your Titanfall2 directory (you can name it whatever you want), and putting in `NorthstarLauncher.exe -norestrictservercommands -profile=R2Vanilla`.
-After doing this, you'll want to rename it to `yourFileName.bat`.
-This tells the NorthstarLauncher to not restrict server commands, a feature which is needed to allow the server to tell the client which server to join (but is disabled on Northstar for security reasons), and tells it to use the `R2Vanilla` profile, which, as it doesn't normally exist, will launch Northstar with no core mods enabled, allowing you to easily play on Vanilla using most of Northstar's security fixes.
-
-Double clicking the `.bat` or right clicking on it and hitting `open` will launch the vanilla profile.
+![SteamEdit using Northstar profiles](../images/steamedit-profiles.png)
 
 ## Setting levels using console commands <a href="#set-level" id="set-level"></a>
 
@@ -42,24 +34,3 @@ With everything unlocked, there is no need to set your level to a higher level, 
 `script GetPlayerArray()[0].SetPersistentVar("xp", INSERT_XP_COUNT)` this command sets the xp count of the player (meaning, the amount of kills required per level in order to level up). You want to replace `INSERT_XP_COUNT` with the number you want. Setting this number lower than 472 is recommended, as to not encounter issues.
 
 If you experience strange issues after using these, you probably set something too high, and should follow the [resetting levels wiki section](../installing-northstar/troubleshooting.md#i-used-a-command-to-set-my-playergun-xp-level-and-i-set-it-too-high-so-now-my-game-crashes-when-trying-to-join-multiplayer).
-
-## Playing Vanilla via NorthstarLauncher <a href="#vanilla-on-northstar" id="vanilla-on-northstar"></a>
-
-It is recommended that you [set up a vanilla profile](advanced.md#profiles) instead of disabling all of your mods and using `-norestrictservercommands` as a launch option, however if you wish to only play vanilla using this method and would rather not set up a profile, you can do the following.
-
-The reason behind doing this is that Northstar has several security fixes that Vanilla does not have, however these are not *necessary*. The odds you get hacked playing vanilla are close to zero, and there are no reports of people being genuinely hacked by playing Vanilla.\
-This method assumes you're launching Northstar via Titanfall 2 on EA or Steam using launch options.
-
-1. Go to the main menu of Northstar 
-2. Click `"Mods"` on the bottom of the menu
-3. Disable **ALL** of your mods
-4. Close Northstar
-5. Add `-norestrictservercommands` and `-northstar` as a [launch option](../installing-northstar/troubleshooting.md#launch-opts)
-6. Launch Titanfall 2 and you should be able to play on vanilla servers using Northstar's security fixes
-
-**TO PLAY ON NORTHSTAR AGAIN**
-
-1. Go to your [Titanfall2 directory](../installing-northstar/troubleshooting.md#game-location)
-2. Open your `R2Northstar` folder
-3. Delete `enabledmods.json`
-4. Launch Northstar

--- a/docs/using-northstar/vanilla.md
+++ b/docs/using-northstar/vanilla.md
@@ -1,0 +1,21 @@
+# Playing vanilla Titanfall 2 via Northstar
+
+While Northstar comes pre-packaged with mods to support community servers and custom content, some users may not want all of this.
+Northstar can also be used to load mods on vanilla more easily and with more stability than vpk modding, and can sometimes help when the game doesn't want to launch at all.
+
+## Launching vanilla Titanfall 2 via Northstar (no mods)
+
+This method of launching Titanfall 2 is generally done when some part of Steam/EA launching Titanfall 2 doesn't work properly.
+You can do this by going to your [Titanfall2 directory](installing-northstar/troubleshooting.md#game-location), creating a `Vanilla.bat` file, right clicking the `Vanilla.bat` file, hitting `Edit`, then entering `NorthstarLauncher.exe -vanilla`.
+
+Once you do this, double click the `Vanilla.bat` file to load vanilla Titanfall 2 via Northstar without mods.
+
+## Launching vanilla Titanfall 2 via Northstar (with mods)
+
+While Northstar is seeing [more progress towards vanilla compatibility](https://github.com/R2Northstar/NorthstarLauncher/pull/601), it's still decently far out.
+A community made modification is available in the form of [VanillaPlus](https://northstar.thunderstore.io/package/NanohmProtogen/VanillaPlus/) to load mods on vanilla.
+It should be noted that, again, this is a community made modification and is not "officially" Northstar.
+
+To use it, read the mod's description on Thunderstore to install it, as it has a special install process compared to other mods.
+If you have any issues, check the [VanillaPlus FAQ](https://github.com/Zayveeo5e/NP.VanillaPlus/blob/main/FAQ.md) to see if you can find your issue there.
+If you can't find your issue on the FAQ, open an issue on the mod's GitHub repo.

--- a/docs/using-northstar/vanilla.md
+++ b/docs/using-northstar/vanilla.md
@@ -3,14 +3,14 @@
 While Northstar comes pre-packaged with mods to support community servers and custom content, some users may not want all of this.
 Northstar can also be used to load mods on vanilla more easily and with more stability than vpk modding, and can sometimes help when the game doesn't want to launch at all.
 
-## Launching vanilla Titanfall 2 via Northstar (no mods)
+## Launching vanilla Titanfall 2 via Northstar (no mods) <a href="#vanilla-without-mods" id="vanilla-without-mods"></a>
 
 This method of launching Titanfall 2 is generally done when some part of Steam/EA launching Titanfall 2 doesn't work properly.
 You can do this by going to your [Titanfall2 directory](../installing-northstar/troubleshooting.md#game-location), creating a `Vanilla.bat` file, right clicking the `Vanilla.bat` file, hitting `Edit`, then entering `NorthstarLauncher.exe -vanilla`.
 
 Once you do this, double click the `Vanilla.bat` file to load vanilla Titanfall 2 via Northstar without mods.
 
-## Launching vanilla Titanfall 2 via Northstar (with mods)
+## Launching vanilla Titanfall 2 via Northstar (with mods) <a href="#vanilla-with-mods" id="vanilla-with-mods"></a>
 
 While Northstar is seeing [more progress towards vanilla compatibility](https://github.com/R2Northstar/NorthstarLauncher/pull/601), it's still decently far out.
 A community made modification is available in the form of [VanillaPlus](https://northstar.thunderstore.io/package/NanohmProtogen/VanillaPlus/) to load mods on vanilla.

--- a/docs/using-northstar/vanilla.md
+++ b/docs/using-northstar/vanilla.md
@@ -6,7 +6,7 @@ Northstar can also be used to load mods on vanilla more easily and with more sta
 ## Launching vanilla Titanfall 2 via Northstar (no mods)
 
 This method of launching Titanfall 2 is generally done when some part of Steam/EA launching Titanfall 2 doesn't work properly.
-You can do this by going to your [Titanfall2 directory](installing-northstar/troubleshooting.md#game-location), creating a `Vanilla.bat` file, right clicking the `Vanilla.bat` file, hitting `Edit`, then entering `NorthstarLauncher.exe -vanilla`.
+You can do this by going to your [Titanfall2 directory](../installing-northstar/troubleshooting.md#game-location), creating a `Vanilla.bat` file, right clicking the `Vanilla.bat` file, hitting `Edit`, then entering `NorthstarLauncher.exe -vanilla`.
 
 Once you do this, double click the `Vanilla.bat` file to load vanilla Titanfall 2 via Northstar without mods.
 


### PR DESCRIPTION
I recently did one of these, however I feel like it really needed work still and was quite confusing to the average user

This version does in fact reference _VanillaPlus_, a mod that I work on, however I think it's for good reason. This reason being that without _VanillaPlus_, mods using Mod Settings will not work (as it's blacklisted due to how many errors it would've caused when it got added to Northstar), and without either downgrading Northstar or renaming the Mod Settings mod (which are both quite the task for a lot of end users), these mods will simply break the game. Additionally, previous methods would omit things such as the mods list, as that is included in `Northstar.Client`, which having enabled would break vanilla.

I've updated the only other source I personally found of vanilla profiles, which was in the VTOL guide

I decided to make the headers not reference _VanillaPlus_ as to more easily update them when vanilla compatibility is included in Northstar. I do not want to "take over" vanilla sections and shill the mod I work on the most, but I feel like it's currently the best solution. I will also be helping with vanilla compatibility in Northstar as much as I can, and deprecating _VanillaPlus_ when it's served it's purpose.