### PR TITLE
Add Arch Wiki to link ignore list

### DIFF
--- a/.github/.markdownlinkcheck.json
+++ b/.github/.markdownlinkcheck.json
@@ -5,6 +5,9 @@
         },
         {
             "pattern": "https://forum.manjaro.org/t/howto-troubleshoot-crackling-in-pipewire/82442"
+        },
+        {
+            "pattern": "https://wiki.archlinux.org/title/PulseAudio/Troubleshooting#Glitches.2C\\_skips\\_or\\_crackling"
         }
     ]
 }


### PR DESCRIPTION
They seem to have uptime issues right now, causing our CI to fail.