### PR TITLE
Fix image placement in `Testing`

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -46,14 +46,15 @@ The tool is still being improved upon but already more than usable. Check its RE
 
 Before starting, make sure you have a **working and up-to-date Northstar install** and you're **logged into GitHub with your GitHub account** (downloading files from CI only works while logged into any GitHub account)!
 
-1. Head to the bottom of the page of the PR and click on "_Show all checks_" ![rcon1](https://user-images.githubusercontent.com/40122905/179726100-48945eb6-3ebe-467f-acef-1c7d56f3e4bd.png)
-2. For "_CI / build (pull\_request)_" click on "_Details_"\
+1. Head to the bottom of the page of the PR and click on "_Show all checks_"\
+   &#x20;![rcon1](https://user-images.githubusercontent.com/40122905/179726100-48945eb6-3ebe-467f-acef-1c7d56f3e4bd.png)
+3. For "_CI / build (pull\_request)_" click on "_Details_"\
    &#x20;![rcon2](https://user-images.githubusercontent.com/40122905/179726993-d1cb7849-a2fc-4d0d-9379-cf4e279469a1.png)
-3. From here click on "_Summary_"\
+4. From here click on "_Summary_"\
    &#x20;![rcon3](https://user-images.githubusercontent.com/40122905/179727326-5e6d64c7-6ff0-472a-ac7d-7e4f04d6bac9.png)
-4. And then click on "_NorthstarLauncher-XXXXXXX_"\
+5. And then click on "_NorthstarLauncher-XXXXXXX_"\
    &#x20;![rcon4](https://user-images.githubusercontent.com/40122905/179727511-877641f8-e5fc-4a34-bcf1-29bafefc1ad2.png)
-5. Once downloaded, open the zip and copy `Northstar.dll` and `NorthstarLauncher.exe` to your Titanfall2 folder, overwriting the existing DLL and EXE in there.
+6. Once downloaded, open the zip and copy `Northstar.dll` and `NorthstarLauncher.exe` to your Titanfall2 folder, overwriting the existing DLL and EXE in there.
 
 Alternatively, compiling the PR'd code from source is also an option. For this, refer to [northstarlauncher.md](repositories/northstarlauncher.md)
 
@@ -67,7 +68,7 @@ Click on _"Code"_ and then on _"Download ZIP"_
 
 ![](../.gitbook/assets/download-mods-pr2.png)
 
-From there copy over all the `Northstar.XXXXX` folders into your mods folder in your TItnafall2 install the same way you would manually install mods.
+From there copy over all the `Northstar.XXXXX` folders into your mods folder in your Titanfall2 install the same way you would manually install mods.
 
 ## Tips and toolkits
 
@@ -105,7 +106,7 @@ By default duplicate accounts are blocked by server. Use `-allowdupeaccounts` wh
 Use `map <map name>` to quickly switch map.\
 Example: `map mp_glitch`
 
-List of maps can be found [here](../hosting-a-server-with-northstar/dedicated-server/#maps)
+List of maps can be found [here](../hosting-a-server-with-northstar/server-settings/file-names.md#maps)
 
 **Speed-up/slow-down game**
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -48,13 +48,13 @@ Before starting, make sure you have a **working and up-to-date Northstar install
 
 1. Head to the bottom of the page of the PR and click on "_Show all checks_"\
    &#x20;![rcon1](https://user-images.githubusercontent.com/40122905/179726100-48945eb6-3ebe-467f-acef-1c7d56f3e4bd.png)
-3. For "_CI / build (pull\_request)_" click on "_Details_"\
+2. For "_CI / build (pull\_request)_" click on "_Details_"\
    &#x20;![rcon2](https://user-images.githubusercontent.com/40122905/179726993-d1cb7849-a2fc-4d0d-9379-cf4e279469a1.png)
-4. From here click on "_Summary_"\
+3. From here click on "_Summary_"\
    &#x20;![rcon3](https://user-images.githubusercontent.com/40122905/179727326-5e6d64c7-6ff0-472a-ac7d-7e4f04d6bac9.png)
-5. And then click on "_NorthstarLauncher-XXXXXXX_"\
+4. And then click on "_NorthstarLauncher-XXXXXXX_"\
    &#x20;![rcon4](https://user-images.githubusercontent.com/40122905/179727511-877641f8-e5fc-4a34-bcf1-29bafefc1ad2.png)
-6. Once downloaded, open the zip and copy `Northstar.dll` and `NorthstarLauncher.exe` to your Titanfall2 folder, overwriting the existing DLL and EXE in there.
+5. Once downloaded, open the zip and copy `Northstar.dll` and `NorthstarLauncher.exe` to your Titanfall2 folder, overwriting the existing DLL and EXE in there.
 
 Alternatively, compiling the PR'd code from source is also an option. For this, refer to [northstarlauncher.md](repositories/northstarlauncher.md)
 


### PR DESCRIPTION
Fixes a misplaced image in the page for manually downloading development Northstar code