### PR TITLE
Embed ModdingDocs link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ Install instructions can be found here:
 
 For modding guides, documentation on Northstar API features and documentation on Respawn Squirrel look at:
 
-[ReadTheDocs](https://r2northstar.readthedocs.io/en/latest/guides/gettingstarted.html)
+{% embed url="https://r2northstar.readthedocs.io/" %}
 
 ## Contact and contributing
 


### PR DESCRIPTION
Embed ModdingDocs link instead of using an inline link

This is done is it renders nicer on GitBook itself.


Before:
![image](https://github.com/R2Northstar/NorthstarWiki/assets/40122905/9e2d124f-3392-41c9-9c4a-8de7b7243bd8)

After:
![image](https://github.com/R2Northstar/NorthstarWiki/assets/40122905/0bfac9ed-19df-4a20-87ce-2eaf2a0a1ec6)

