### PR TITLE
Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: md-linkcheck
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:


### PR DESCRIPTION
v3 uses Node 16 which is slated for deprecation by GitHub Actions