### PR TITLE
Add current rules from Discord

### DIFF
--- a/docs/other/moderation/rules.md
+++ b/docs/other/moderation/rules.md
@@ -4,4 +4,48 @@ This is a copy of the current list of rules on the Northstar Discord server.
 They are copied here for transparency reasons so any change to them can be tracked and easily observed.
 
 ```markdown
+This is a public server that anyone is welcome to join. As such, we expect everybody who participates to keep things civil. To that end, we've established some guidelines for this server. Failing to follow these rules may result in your posts being removed, limitations of your permissions in channels, or removal from this server. ──────────────────────────────────────────────────────────────────────────────────────────────────────
+
+**1. Be respectful.** This includes insults, harassment, or otherwise hateful conduct. If you disagree with somebody, don't be uncivilized about it.
+**2. No NSF(W/L) content.** We all have to sleep at night. If you post content that would get you fired at work, you're going to get the boot.
+**3. No illicit activity.** This includes account trading / selling, piracy, witch hunting, or any discussion of illegal or otherwise unseemly activity.
+**4. No spam.** This includes but is not limited to brigading, link-spamming, or general rapid-fire spam.
+**5. Keep profanity to a minimum.** If you wouldn't say it in front of police, you should avoid saying it here.
+**6. Limit self-promotion.** Refrain from sharing your content outside of applicable conversation or dedicated channels.
+**7. Stay on-topic.** We know conversations will take their own route, but please try to keep discussion to the appropriate channels.
+**8. No politics.** This includes hot-button social subjects. While some commentary on politics and society is unavoidable, this is not the platform for those discussions.
+**9. No sharing private information.** Content that includes someone's personally identifiable information or private messages should be anonymized or they may be deleted.
+**10. Don't break anything.** Do not share, take advantage of, or demonstrate exploits or bugs in this server. For security vulnerabilities, you can report them to any of the staff.
+**11. No mudslinging.** Constructive criticism and critical discussion is welcome, but personal attacks or defamatory and disparaging statements about individuals or entities are not.
+**12. No unnecessary pinging.** Ping if absolutely necessary, especially if you're going to ping staff.
+**13. Please use English.** It's known as the most used international language.
+**14. Good manners.** This means strictly no topics that would divert or derail the current conversation being held, especially those of sexual innuendos.
+**15. No hating/flaming about moderation decisions**. If you want to discuss moderation decisions (bans, mutes, changes, ...) please open a staff only ticket in ⁠help . Harassing a mod will get you banned.
+**16. Follow discord ToS**. We don't enforce it as much but if we find you worthy of a ban we won't hesitate. ──────────────────────────────────────────────────────────────────────────────────────────────────────
+
+**Ban Guidelines**
+
+> 1) If you don't follow the rules we will first warn you using Dyno. This creates a modlog of your user on this server.
+> 2) After 3 warnings this will result into a 24 hour mute. In that time we kindly ask you to reflect on your messages/actions and hope you will be back after your timeout.
+> 3) If you insist on not following the rules we will then proceed to ban you.
+> 4) If you think your ban is not justified or reflected on your behaviour, you can file a ban appeal so we can overthink your permanent ban.
+
+**Immediate Bans**
+
+> 1) NSFW (Not Safe For Work) or NSFL (Not Safe For Life*).
+>    * NSFL: Wishing for death, watching people die, jokes about people getting harmed, suicide.
+> 2) Scam links / your account got hacked (please file an appeal after your account has 2FA enabled/passwords changed).
+> 3) Harassing a moderator about decisions (see rule 15).
+> 4) Ban evading
+
+Please note:
+
+> **These rules are not comprehensive.** Moderators and staff may remove content, administer reprimands, or warn users for violations not codified here at their discretion. If a moderator or staff member asks you to stop doing something, please respect their request.
+**Staff and Other VIPs may be exempt** (to some extent) from any of these rules due to their reputation in the community, if you feel like they should be warned for a violation you should report to staff
+
+For questions regarding Discord's Privacy Policy or Terms of Use, please refer to the documents here (https://discord.com/terms)
+`Last Updated` 6 July 2022 17:52`, All rights reserved`
+https://discord.gg/northstar
+New users, **you can go to #⁠installation to find out how to install Northstar** as well as read the FAQ if you have any questions
+**If you get an issue whilst installing/playing please open a ticket in ⁠#help** (Do not go to ⁠#general to fix it)
 ```


### PR DESCRIPTION
Add the current rules of the Discord server.

The rules where committed as @xamionex as they were the last person to post them in the `#rules` channel and exact attribution is quite difficult at this time as the message is over two years old now.