### PR TITLE
Ignore Taskinoz' server browser  for linkcheck

### DIFF
--- a/.github/.markdownlinkcheck.json
+++ b/.github/.markdownlinkcheck.json
@@ -10,6 +10,9 @@
             "pattern": "https://forum.manjaro.org/t/howto-troubleshoot-crackling-in-pipewire/82442"
         },
         {
+            "pattern": "https://taskinoz.com/northstar/"
+        },
+        {
             "pattern": "https://wiki.archlinux.org/title/PulseAudio/Troubleshooting#Glitches.2C\\_skips\\_or\\_crackling"
         }
     ]


### PR DESCRIPTION
https://taskinoz.com/northstar/ seems to either take too long to respond or falsely detect us as spam so easiest is to just skip it during linkcheck
