### PR TITLE
Add link that shows changes to rules

### DIFF
--- a/docs/other/moderation/rules.md
+++ b/docs/other/moderation/rules.md
@@ -3,6 +3,8 @@
 This is a copy of the current list of rules on the Northstar Discord server.
 They are copied here for transparency reasons so any change to them can be tracked and easily observed.
 
+In particular you can check changes to the rules on GitHub using the following link: https://github.com/R2Northstar/NorthstarWiki/commits/main/docs/other/moderation/rules.md
+
 ```markdown
 This is a public server that anyone is welcome to join. As such, we expect everybody who participates to keep things civil. To that end, we've established some guidelines for this server. Failing to follow these rules may result in your posts being removed, limitations of your permissions in channels, or removal from this server. ──────────────────────────────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Adds a link to https://github.com/R2Northstar/NorthstarWiki/commits/main/docs/other/moderation/rules.md which shows the history of the rules page on GitHub.