### PR TITLE
Remove dead link to Lutris Origin documentation

### DIFF
--- a/docs/steamdeck-and-linux/linux-troubleshooting.md
+++ b/docs/steamdeck-and-linux/linux-troubleshooting.md
@@ -1,7 +1,5 @@
 # Troubleshooting
 
-> Read Lutris troubleshooting of [common issues with Origin](https://github.com/lutris/docs/blob/master/Origin.md) first.
-
 ## Northstar not launching with Steam
 
 If you're encountering issues with Northstar launching on Steam, a very quick fix that usually works is deleting the compatdata for Titanfall2.


### PR DESCRIPTION
The readme that was linked to was recently removed upstream resulting in a 404. As Origin support in Lutris is being deprecated it makes no sense to keep linking to a page that is no longer up-to-date