### PR TITLE
Mention installing Northstar via website in rules

### DIFF
--- a/docs/other/moderation/rules.md
+++ b/docs/other/moderation/rules.md
@@ -48,9 +48,9 @@ Please note:
 **Staff and Other VIPs may be exempt** (to some extent) from any of these rules due to their reputation in the community, if you feel like they should be warned for a violation you should report to staff
 
 For questions regarding Discord's Privacy Policy or Terms of Use, please refer to the documents here (<https://discord.com/terms>)
-`Last Updated: 2024-07-14`
+`Last Updated: 2024-08-15`
 <https://discord.gg/northstar>
 
-New users, **you can go to #installation to find out how to install Northstar** as well as read the FAQ if you have any questions
+New users, **you can install Northstar via <https://northstar.tf>**
 **If you get an issue whilst installing/playing please open a ticket in #help** (Do not go to #general to fix it)
 ```


### PR DESCRIPTION
The `#installation` channel has been archived based on a joint moderation decision to reduce channel clutter. The recommend installation is via the webpage.