### PR TITLE
Use channel identifier instead of channel name

### DIFF
--- a/docs/other/moderation/rules.md
+++ b/docs/other/moderation/rules.md
@@ -52,5 +52,5 @@ For questions regarding Discord's Privacy Policy or Terms of Use, please refer t
 `Last Updated: 2024-08-15`
 <https://discord.gg/northstar>
 
-**If you have any issues regarding Northstar during your time playing or installing**, please open a support ticket in #⁠get-support-here. This channel is dedicated to helping users and should be used for this purpose instead of #⁠general and other similar chats.
+**If you have any issues regarding Northstar during your time playing or installing**, please open a support ticket in <#922663326994018366>. This channel is dedicated to helping users and should be used for this purpose instead of `#⁠general` and other similar chats.
 ```

--- a/docs/other/moderation/rules.md
+++ b/docs/other/moderation/rules.md
@@ -49,7 +49,7 @@ Please note:
 **Staff and Other VIPs may be exempt** (to some extent) from any of these rules due to their reputation in the community, if you feel like they should be warned for a violation you should report to staff
 
 For questions regarding Discord's Privacy Policy or Terms of Use, please refer to the documents here (<https://discord.com/terms>)
-`Last Updated: 2024-08-15`
+`Last Updated: 2024-08-18`
 <https://discord.gg/northstar>
 
 **If you have any issues regarding Northstar during your time playing or installing**, please open a support ticket in <#922663326994018366>. This channel is dedicated to helping users and should be used for this purpose instead of `#⁠general` and other similar chats.


### PR DESCRIPTION
Use channel identifier instead of channel name so that the channel name is clickable when posting the rules

This only applies to the `#get-support-here` channel as we don't want the mention of `#general` to be clickable to further reduce the chance of someone entering that channel for support as `#general` is not designed to give tech support.