### PR TITLE
Update release steps in regards to release branches

### DIFF
--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -27,9 +27,9 @@ The process is ever changing in order to simplify it so these steps outlined mig
 
 The current process of making release (includinging release candidate) is:
 
-1. Make release branch (`MAJOR.MINOR.X`) (if not exists)
+1. Make release branch (`MAJOR.MINOR.X`) (only if commits need to be cherry-picked)
 
-2. Merge desired commits from `main`
+2. Take desired commits from `main`
     - Make sure to consider whether changing are breaking in regards to older/newer server/client and in regards to Squirrel API.
       - Older/newer client/server breakage might need to be version gated and should **NOT** be done in patch releases.
       - Squirrel API changes likely breaks mods and should **NOT** be done in patch releases. Additionaly make sure to ping modders on release or preferably even in advance.


### PR DESCRIPTION
Update release steps in regards to release branches based on the fact that we now only create release branches if they are actually necessary.