### PR TITLE
Add workaround for EA App failing to launch to Linux installation instructions

### DIFF
--- a/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
+++ b/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
@@ -14,20 +14,27 @@ NorthstarProton has some problems and may stop working at any point, if this hap
 
 On Steam Deck, complete the following in desktop mode. You may return to game mode once completed _(A mouse + keyboard plugged into the Deck are recommended for easier navigation of menus)_
 
-1. Make sure you ran the vanilla version of Titanfall2 at least once on Linux!
-   * If you use an Nvidia GPU you may need to start the game using Proton 6.3-8 for the first time
+1. Make sure you ran the vanilla version of Titanfall 2 at least once on Linux!
+   * If Titanfall 2 fails to launch, you may have to delete the game's Proton prefix and reinstall using another version of Proton.
+   1. To do this, head to `~/.local/share/Steam/steamapps/compatdata` if you installed Steam via a native package, or the Flatpak equivalent.
+   2. Delete the folder named `1237970`
+   3. Set Titanfall 2 to launch with Proton 6.3-8 or 7.0-6 in the _Properties_ -> _Compatibility_ section.
+   4. Launch the game and allow the install to completely finish.
+   5. Set Titanfall 2 to launch with a more current version of Proton, NorthstarProton, or Proton GE.
+   6. If Titanfall 2 still fails to launch, delete the prefix again and try installing with the other version of Proton.
 2. Install the latest version of Northstar using [FlightCore](../installing-northstar/northstar-installers#geckoeidechse-flightcore), [Viper](../installing-northstar/northstar-installers#0negal-viper), or do it manually
    1. For manual install download the latest version of Northstar from the [releases](https://github.com/R2Northstar/Northstar/releases) page
    2. Then extract all contents of the file to your Titanfall 2 folder ( Right click _Titanfall 2_ > Open _Properties_ > Click _Local Files_ > Click _Browse_ )
-3. Install NorthstarProton
+3. Install NorthstarProton or a current version of Proton GE.
+   * In some user cases, NorthstarProton may not work. You may instead try Proton GE, which is also available through the following methods.
    1. **Protonup-QT**: Click _About_, then tick the box to enable _advanced mode_. You should be able to select and install NorthstarProton from the _Add version_ menu.
    2. **ProtonPlus**: NorthstarProton can also be installed via ProtonPlus.
    3. **Manual**: Download the latest release of [NorthstarProton](https://github.com/cyrv6737/NorthstarProton/releases/), extract it, and place the folder in one of the following directories:
       * **Steam (Native Package) & Steam Deck:** `~/.local/share/Steam/compatibilitytools.d`
       * **Steam (Flatpak):** `~/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d/`
-4. Restart Steam. Head to `Properties -> Compatibility` under Titanfall2. Check `Force the use of a specific Steam Play compatibility tool` checkbox, then set the Steam Play compatibility tool to NorthstarProton.
-5. Add `%command% -northstar` as a [launch option](../installing-northstar/troubleshooting.md#launch-opts) to Titanfall2
-6. Launch Titanfall2, it should now launch Northstar
+5. Restart Steam. Head to `Properties -> Compatibility` under Titanfall2. Check `Force the use of a specific Steam Play compatibility tool` checkbox, then set the Steam Play compatibility tool to NorthstarProton.
+6. Add `%command% -northstar` as a [launch option](../installing-northstar/troubleshooting.md#launch-opts) to Titanfall2
+7. Launch Titanfall2, it should now launch Northstar
 
 Note that removing the `%command% -northstar` will cause Steam to launch the vanilla game again.
 

--- a/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
+++ b/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
@@ -14,7 +14,7 @@ NorthstarProton has some problems and may stop working at any point, if this hap
 
 On Steam Deck, complete the following in desktop mode. You may return to game mode once completed _(A mouse + keyboard plugged into the Deck are recommended for easier navigation of menus)_
 
-1. Make sure you ran the vanilla version of Titanfall 2 at least once on Linux!
+1. Make sure you ran the vanilla version of Titanfall2 at least once on Linux!
    * If Titanfall 2 fails to launch, you may have to delete the game's Proton prefix and reinstall using another version of Proton.
    1. To do this, head to `~/.local/share/Steam/steamapps/compatdata` if you installed Steam via a native package, or the Flatpak equivalent.
    2. Delete the folder named `1237970`
@@ -32,9 +32,9 @@ On Steam Deck, complete the following in desktop mode. You may return to game mo
    3. **Manual**: Download the latest release of [NorthstarProton](https://github.com/cyrv6737/NorthstarProton/releases/), extract it, and place the folder in one of the following directories:
       * **Steam (Native Package) & Steam Deck:** `~/.local/share/Steam/compatibilitytools.d`
       * **Steam (Flatpak):** `~/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d/`
-5. Restart Steam. Head to `Properties -> Compatibility` under Titanfall2. Check `Force the use of a specific Steam Play compatibility tool` checkbox, then set the Steam Play compatibility tool to NorthstarProton.
-6. Add `%command% -northstar` as a [launch option](../installing-northstar/troubleshooting.md#launch-opts) to Titanfall2
-7. Launch Titanfall2, it should now launch Northstar
+4. Restart Steam. Head to `Properties -> Compatibility` under Titanfall2. Check `Force the use of a specific Steam Play compatibility tool` checkbox, then set the Steam Play compatibility tool to NorthstarProton.
+5. Add `%command% -northstar` as a [launch option](../installing-northstar/troubleshooting.md#launch-opts) to Titanfall2
+6. Launch Titanfall2, it should now launch Northstar
 
 Note that removing the `%command% -northstar` will cause Steam to launch the vanilla game again.
 

--- a/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
+++ b/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
@@ -18,7 +18,7 @@ On Steam Deck, complete the following in desktop mode. You may return to game mo
    * If Titanfall 2 fails to launch, you may have to delete the game's Proton prefix and reinstall using another version of Proton.
    1. To do this, head to `~/.local/share/Steam/steamapps/compatdata` if you installed Steam via a native package, or the Flatpak equivalent.
    2. Delete the folder named `1237970`
-   3. Set Titanfall 2 to launch with Proton 6.3-8 or 7.0-6 in the _Properties_ -> _Compatibility_ section.
+   3. Set Titanfall 2 to launch with `Proton 6.3-8` or `Proton 7.0-6` in the _Properties_ -> _Compatibility_ section.
    4. Launch the game and allow the install to completely finish.
    5. Set Titanfall 2 to launch with a more current version of Proton, NorthstarProton, or Proton GE.
    6. If Titanfall 2 still fails to launch, delete the prefix again and try installing with the other version of Proton.


### PR DESCRIPTION
expansion instruction

<!-- 
BEFORE OPENING A PULL REQUEST:
-> If you're adding multiple independent changes (e.g. adding a section about modding while also fixing a typo on another page) it's generally recommended to split these changes into separate pull requests.

Note that pull requests containing lots of unhelpful commit messages will generally be squashed to keep commit history clean.
-->

PR to provide more robust instructions on getting Titanfall 2 / Northstar to actually launch. 6.3-8 isn't a bulletproof method anymore and NorthstarProton also doesn't universally work. Feel free to edit the formatting, my goal was simply to convey the different things some people have to do (6.3-8 vs 7.0-6 install / Proton GE vs NorthstarProton for playing)