### PR TITLE
Update link to ModdingDocs to new docs version

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ Install instructions can be found here:
 
 For modding guides, documentation on Northstar API features and documentation on Respawn Squirrel look at:
 
-{% embed url="https://r2northstar.readthedocs.io/" %}
+{% embed url="https://docs.northstar.tf/Modding/" %}
 
 ## Contact and contributing
 

--- a/docs/modding/README.md
+++ b/docs/modding/README.md
@@ -1,6 +1,6 @@
 # Modding
 
-Northstar Modding documentation has moved over to: [https://r2northstar.readthedocs.io/](https://r2northstar.readthedocs.io/).
+Northstar Modding documentation has moved over to: [https://docs.northstar.tf/Modding/](https://docs.northstar.tf/Modding/).
 
 ## Custom Skin Modding
 


### PR DESCRIPTION
Replaces links from https://r2northstar.readthedocs.io/ with https://docs.northstar.tf/Modding/
