### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 > The GitBook based NorthstarWiki has been deprecated in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
 > 
 > Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+> 
 > The source for the NorthstarDocs can be found here: [https://github.com/R2Northstar/NorthstarDocs](https://github.com/R2Northstar/NorthstarDocs)
 
 This repo contains documentation around the [Northstar mod](https://github.com/R2Northstar), a Titanfall 2 mod to join and host custom community servers.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Northstar Wiki Repo
 
+> [!WARNING]  
+> The GitBook based NorthstarWiki has been deprecated in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+> 
+> Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+> The source for the NorthstarDocs can be found here: [https://github.com/R2Northstar/NorthstarDocs](https://github.com/R2Northstar/NorthstarDocs)
+
 This repo contains documentation around the [Northstar mod](https://github.com/R2Northstar), a Titanfall 2 mod to join and host custom community servers.
 
 The `docs/` directory contains the content synchronised to the [GitBook Wiki page](https://r2northstar.gitbook.io/).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,15 @@ description: A Titanfall|2 mod to join and host custom servers.
 cover: images/northstarbanner.png
 ---
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/./
+
+{% endhint %}
+
 # Welcome to Northstar
 
 {% embed url="https://www.youtube.com/watch?v=en06Y6CPMQg" %}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,6 +2,15 @@
 description: Contribution guidelines
 ---
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/contributing
+
+{% endhint %}
+
 # Contributing
 
 ## Creating an issue <a href="#contributing" id="contributing"></a>

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -4,6 +4,15 @@ description: >-
   it.
 ---
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/
+
+{% endhint %}
+
 # Development
 
 Check the subpages on the sidebar for various aspects of Northstar development.

--- a/docs/development/contributing-code-to-northstar.md
+++ b/docs/development/contributing-code-to-northstar.md
@@ -2,6 +2,15 @@
 description: Useful information when contributing to Northstar
 ---
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/contributing-code-to-northstar
+
+{% endhint %}
+
 # Contributing code to Northstar
 
 {% hint style="info" %}

--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -1,6 +1,15 @@
 # Debugging
 
 {% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/debugging/
+
+{% endhint %}
+
+{% hint style="warning" %}
 Debugging Northstar is only recommended to experienced developers.
 If you need help figuring out an issue feel free to visit the Northstar Discord.
 {% endhint %}

--- a/docs/development/debugging/visualstudio.md
+++ b/docs/development/debugging/visualstudio.md
@@ -1,5 +1,14 @@
 # Visual Studio
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/debugging/visualstudio
+
+{% endhint %}
+
 Northstar is easiest to debug through Visual Studio due to its cmake support.
 
 

--- a/docs/development/debugging/x64dbg.md
+++ b/docs/development/debugging/x64dbg.md
@@ -1,6 +1,15 @@
 # x64dbg
 
 {% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/debugging/x64dbg
+
+{% endhint %}
+
+{% hint style="warning" %}
 If you are not experienced with x64dbg it its recommended to use [Visual Studio](visualstudio.md).
 {% endhint %}
 

--- a/docs/development/northstarmasterserver/README.md
+++ b/docs/development/northstarmasterserver/README.md
@@ -1,6 +1,15 @@
 # NorthstarMasterServer
 
 {% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/northstarmasterserver/
+
+{% endhint %}
+
+{% hint style="warning" %}
 The old NodeJS master server has been replaced in favour of the Go rewrite called Atlas.
 {% endhint %}
 

--- a/docs/development/northstarmasterserver/deploy.md
+++ b/docs/development/northstarmasterserver/deploy.md
@@ -1,5 +1,14 @@
 # Deploy
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/northstarmasterserver/deploy
+
+{% endhint %}
+
 ## Development
 
 A Development Master Server uses http requests, it should be used for development purposes on your local machine.

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -4,6 +4,15 @@ description: >-
   new releases
 ---
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/releases
+
+{% endhint %}
+
 # Releases
 
 {% hint style="info" %}

--- a/docs/development/repositories/README.md
+++ b/docs/development/repositories/README.md
@@ -1,5 +1,14 @@
 # Repositories
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/repositories/
+
+{% endhint %}
+
 Northstar is split over multiple git repositories that fulfill different functions.
 
 * [Atlas](https://github.com/R2Northstar/Atlas):\

--- a/docs/development/repositories/atlas.md
+++ b/docs/development/repositories/atlas.md
@@ -2,6 +2,15 @@
 description: A new Northstar master server written in Go
 ---
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/repositories/atlas
+
+{% endhint %}
+
 # Atlas
 
 TODO

--- a/docs/development/repositories/northstarlauncher.md
+++ b/docs/development/repositories/northstarlauncher.md
@@ -1,5 +1,14 @@
 # NorthstarLauncher
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/repositories/northstarlauncher
+
+{% endhint %}
+
 ### Setup
 
 Build instructions for the launcher can be found here:

--- a/docs/development/repositories/northstarmods.md
+++ b/docs/development/repositories/northstarmods.md
@@ -2,6 +2,15 @@
 description: Core squirrel mods
 ---
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/repositories/northstarmods
+
+{% endhint %}
+
 # NorthstarMods
 
 TODO

--- a/docs/development/reviewing.md
+++ b/docs/development/reviewing.md
@@ -5,6 +5,15 @@ description: >-
   review in general.
 ---
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/reviewing
+
+{% endhint %}
+
 # Reviewing
 
 For new pull requests to be merged into any of the Northstar repos, they need to reviewed to reduce the changes of introducing bugs as well as ensuring that in case of a feature it's something the community actually wants.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -4,6 +4,15 @@ description: >-
   maintainers
 ---
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/testing
+
+{% endhint %}
+
 # Testing
 
 {% hint style="info" %}

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,6 +2,15 @@
 description: Frequently asked questions
 ---
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/faq
+
+{% endhint %}
+
 # FAQ
 
 ## **If you have any issues please go to [the troubleshooting page.](installing-northstar/troubleshooting.md)**

--- a/docs/hosting-a-server-with-northstar/basic-listen-server.md
+++ b/docs/hosting-a-server-with-northstar/basic-listen-server.md
@@ -1,5 +1,14 @@
 # Hosting a Basic Listen Server
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/basic-listen-server
+
+{% endhint %}
+
 ## Requirements
 
 Make sure to check that your server is reachable as [described here](./getting-started.md)

--- a/docs/hosting-a-server-with-northstar/dedicated-server/README.md
+++ b/docs/hosting-a-server-with-northstar/dedicated-server/README.md
@@ -1,5 +1,14 @@
 # Hosting a Dedicated Server
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/
+
+{% endhint %}
+
 ## Hosting a Dedicated Server
 
 ### Setup

--- a/docs/hosting-a-server-with-northstar/dedicated-server/best-practices.md
+++ b/docs/hosting-a-server-with-northstar/dedicated-server/best-practices.md
@@ -2,6 +2,15 @@
 description: Tweaks and tricks to improve both your experience in hosting and others' in playing on your server
 ---
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/best-practices
+
+{% endhint %}
+
 # Best practices
 
 {% hint style="info" %}

--- a/docs/hosting-a-server-with-northstar/dedicated-server/hosting-on-linux.md
+++ b/docs/hosting-a-server-with-northstar/dedicated-server/hosting-on-linux.md
@@ -1,5 +1,14 @@
 # Hosting on Linux
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/hosting-on-linux
+
+{% endhint %}
+
 {% hint style="info" %}
 This page is currently work-in-progress.
 {% endhint %}

--- a/docs/hosting-a-server-with-northstar/dedicated-server/hosting-on-windows.md
+++ b/docs/hosting-a-server-with-northstar/dedicated-server/hosting-on-windows.md
@@ -1,5 +1,14 @@
 # Hosting on Windows
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/hosting-on-windows
+
+{% endhint %}
+
 ## Minimum requirements
 
 The current minimum requirements are as follows:

--- a/docs/hosting-a-server-with-northstar/getting-started.md
+++ b/docs/hosting-a-server-with-northstar/getting-started.md
@@ -1,5 +1,14 @@
 # Getting started
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/getting-started
+
+{% endhint %}
+
 **TL;DR:** Port forward `37015` (UDP), and no [CGNAT](getting-started.md#cgnat)
 
 Make sure you already installed Northstar [as described here](../installing-northstar/basic-setup.md).

--- a/docs/hosting-a-server-with-northstar/local-only-server.md
+++ b/docs/hosting-a-server-with-northstar/local-only-server.md
@@ -1,5 +1,14 @@
 # Hosting a Local-Only Server
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/local-only-server
+
+{% endhint %}
+
 If you just want to host server (listen or dedicated) for people in your local network (as in computer network, not the in-game Networks system), you can simply not enable port-forwarding and set `ns_auth_allow_insecure` to `1` in the `autoexec_ns_server.cfg`.
 
 This way players can connect to your server directly by using the `connect` command with the local IP of your server, e.g. `connect 192.168.420.500` (replace with actual local IP of your server).

--- a/docs/hosting-a-server-with-northstar/server-settings/README.md
+++ b/docs/hosting-a-server-with-northstar/server-settings/README.md
@@ -1,5 +1,14 @@
 #### Useful configuration files
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/
+
+{% endhint %}
+
 You can edit these files to change settings for your dedicated and listening server:
 
 * `ns_startup_args_dedi.txt`\

--- a/docs/hosting-a-server-with-northstar/server-settings/banlist.md
+++ b/docs/hosting-a-server-with-northstar/server-settings/banlist.md
@@ -1,5 +1,14 @@
 # Banlist
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/banlist
+
+{% endhint %}
+
 The `banlist.txt` file found at `R2Northstar\banlist.txt` is a list of players that you have either banned or unbanned from your server.
 
 The UIDs can be formatted as shown below:

--- a/docs/hosting-a-server-with-northstar/server-settings/convars.md
+++ b/docs/hosting-a-server-with-northstar/server-settings/convars.md
@@ -1,5 +1,14 @@
 # Convars
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/convars
+
+{% endhint %}
+
 Convars are located inside the `R2Northstar\mods\Northstar.CustomServers\mod\cfg\autoexec_ns_server.cfg` file.
 
 They allow the server admin to set server's properties like the name, port, and description.

--- a/docs/hosting-a-server-with-northstar/server-settings/file-names.md
+++ b/docs/hosting-a-server-with-northstar/server-settings/file-names.md
@@ -1,5 +1,14 @@
 ### Vanilla
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/file-names
+
+{% endhint %}
+
 | Playlist | Title |
 | --- | --- |
 | private_match | Private Match |

--- a/docs/hosting-a-server-with-northstar/server-settings/playlistvar.md
+++ b/docs/hosting-a-server-with-northstar/server-settings/playlistvar.md
@@ -1,6 +1,15 @@
 ### Playlist overrides
 
 {% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/playlistvar
+
+{% endhint %}
+
+{% hint style="warning" %}
 Playlist overrides determines the behaviour of the server. PlaylistOverrides can be added using the `+setplaylistvaroverrides` argument in the `ns_startup_args_dedi.txt` file.
 
 The list of playlist overrides needs to be quoted and separated by spaces.\

--- a/docs/hosting-a-server-with-northstar/server-settings/startup-args.md
+++ b/docs/hosting-a-server-with-northstar/server-settings/startup-args.md
@@ -1,5 +1,14 @@
 ## Startup Arguments
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/startup-args
+
+{% endhint %}
+
 Startup arguments can be added in the `ns_startup_args_dedi.txt` file.\
 Example: `+setplaylist private_match +mp_gamemode ps`
 

--- a/docs/hosting-a-server-with-northstar/troubleshooting.md
+++ b/docs/hosting-a-server-with-northstar/troubleshooting.md
@@ -1,5 +1,14 @@
 # Troubleshooting
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/troubleshooting
+
+{% endhint %}
+
 ### If server is reachable using external IP
 
 **Your GameServer is out of date**

--- a/docs/installing-northstar/basic-setup.md
+++ b/docs/installing-northstar/basic-setup.md
@@ -1,5 +1,14 @@
 # Basic Setup
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/basic-setup
+
+{% endhint %}
+
 ## Installing Northstar using an installer (recommended):
 
 Head over to the installer page and pick one of the existing installers. All of these take care of both installing and updating Northstar.

--- a/docs/installing-northstar/manual-installation.md
+++ b/docs/installing-northstar/manual-installation.md
@@ -1,5 +1,14 @@
 # Manual installation
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/manual-installation
+
+{% endhint %}
+
 ## Installing Northstar:
 {% embed url="https://www.youtube.com/watch?v=bK4pV-AHOHM" %}
 

--- a/docs/installing-northstar/northstar-installers/README.md
+++ b/docs/installing-northstar/northstar-installers/README.md
@@ -1,5 +1,14 @@
 # Northstar Installers
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/
+
+{% endhint %}
+
 Since the public release of Northstar, the wider community has created tools to automate mod installation, as well as adding additional features such as auto-updating the current Northstar install and mod management.
 
 Each of these installers covers a different use case. Use the table below to find out which one suits you best:

--- a/docs/installing-northstar/northstar-installers/flightcore-guide.md
+++ b/docs/installing-northstar/northstar-installers/flightcore-guide.md
@@ -1,5 +1,14 @@
 # FlightCore Guide
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/flightcore-guide
+
+{% endhint %}
+
 FlightCore is a Northstar installer and mod manager which allows for installing, updating, and managing mods for the Northstar client made for Titanfall 2.
 
 Something to note is that FlightCore works on both Windows and Linux. The setup process is similar for both, except for the installation folder, and how you install FlightCore. 

--- a/docs/installing-northstar/northstar-installers/viper-guide.md
+++ b/docs/installing-northstar/northstar-installers/viper-guide.md
@@ -1,5 +1,14 @@
 # Viper Guide
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/viper-guide
+
+{% endhint %}
+
 Viper is a mod manager/installer for Northstar, a community made mod for Titanfall 2, that automatically updates mods and Northstar versions.
 
 Similar to FlightCore, Viper works on both Windows and Linux and has similar use cases, mostly differing in downloading Viper.

--- a/docs/installing-northstar/northstar-installers/vtol-guide.md
+++ b/docs/installing-northstar/northstar-installers/vtol-guide.md
@@ -1,5 +1,14 @@
 # VTOL Guide
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/vtol-guide
+
+{% endhint %}
+
 VTOL is a mod manager for installing and managing mods for the Northstar client made for Titanfall 2.
 
 VTOL works on Windows only and you can find links to download it on [Northstar's website](https://northstar.tf) or [VTOL's GitHub repo](https://github.com/R2NorthstarTools/VTOL).

--- a/docs/installing-northstar/troubleshooting.md
+++ b/docs/installing-northstar/troubleshooting.md
@@ -1,5 +1,14 @@
 # Troubleshooting
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/troubleshooting
+
+{% endhint %}
+
 Generally try to first launch the vanilla game (i.e. not Northstar) if you encounter any issue and see if it also occurs there as well. Some problems can occur when the vanilla game was never launched before using Northstar.
 
 A lot of problems around the game failing to communicate with EA/Origin can also be prevented by launching EA/Origin before Northstar should you encounter any issues in that regard.

--- a/docs/modding/README.md
+++ b/docs/modding/README.md
@@ -1,5 +1,14 @@
 # Modding
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/modding/
+
+{% endhint %}
+
 Northstar Modding documentation has moved over to: [https://docs.northstar.tf/Modding/](https://docs.northstar.tf/Modding/).
 
 ## Custom Skin Modding

--- a/docs/other/credits.md
+++ b/docs/other/credits.md
@@ -1,5 +1,14 @@
 # Credits
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/other/credits
+
+{% endhint %}
+
 Northstar is being developed by a passionate community that wants to maintain Titanfall 2 and allow everyone to play it forever. Thanks to everyone that contributed to this project in any way.
 
 ## Contributors

--- a/docs/other/helping.md
+++ b/docs/other/helping.md
@@ -1,5 +1,14 @@
 # Helping
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/other/helping
+
+{% endhint %}
+
 This section is meant mostly for those that will be actively helping others in the Northstar Discord server or otherwise.
 If you've somehow stumbled upon this page trying to fix an issue for yourself, you should try checking the [troubleshooting page](../installing-northstar/troubleshooting.md) instead. 
 If you're a helper, it also isn't a bad idea to look at this page a few times and try to have a rough idea of the things that are on it.

--- a/docs/other/moderation/README.md
+++ b/docs/other/moderation/README.md
@@ -1,5 +1,14 @@
 # Moderation
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/other/moderation/
+
+{% endhint %}
+
 {% hint style="info" %}
 This page contains information targetted at Discord moderators.
 {% endhint %}

--- a/docs/other/moderation/rules.md
+++ b/docs/other/moderation/rules.md
@@ -1,5 +1,14 @@
 # Rules
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/other/moderation/rules
+
+{% endhint %}
+
 This is a copy of the current list of rules on the Northstar Discord server.
 They are copied here for transparency reasons so any change to them can be tracked and easily observed.
 

--- a/docs/steamdeck-and-linux/README.md
+++ b/docs/steamdeck-and-linux/README.md
@@ -1,3 +1,12 @@
 # SteamDeck and Linux
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/steamdeck-and-linux/
+
+{% endhint %}
+
 Northstar is officially supported on SteamDeck and Linux. Check the subpages for installation, usage, and troubleshooting information.

--- a/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
+++ b/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
@@ -1,5 +1,14 @@
 # Installing on SteamDeck and Linux
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/steamdeck-and-linux/installing-on-steamdeck-and-linux
+
+{% endhint %}
+
 ## Steam & Steam Deck (NorthstarProton)
 
 {% hint style="warning" %}

--- a/docs/steamdeck-and-linux/linux-troubleshooting.md
+++ b/docs/steamdeck-and-linux/linux-troubleshooting.md
@@ -1,5 +1,14 @@
 # Troubleshooting
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/steamdeck-and-linux/linux-troubleshooting
+
+{% endhint %}
+
 ## Northstar not launching with Steam
 
 If you're encountering issues with Northstar launching on Steam, a very quick fix that usually works is deleting the compatdata for Titanfall2.

--- a/docs/using-northstar/README.md
+++ b/docs/using-northstar/README.md
@@ -1,3 +1,12 @@
 # Using Northstar
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/
+
+{% endhint %}
+
 This section covers various aspects about using Northstar. Check the subpages for more info.

--- a/docs/using-northstar/advanced.md
+++ b/docs/using-northstar/advanced.md
@@ -1,6 +1,15 @@
 # Advanced Options
 
 {% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/advanced
+
+{% endhint %}
+
+{% hint style="warning" %}
 This is a section detailing the more advanced parts of using Northstar, with some of them having a chance to potentially mess with your game. Setting your level too high, for example, will lock you out of Northstar's multiplayer until you reset your entire player stats, progress, and loadouts.
 {% endhint %}
 

--- a/docs/using-northstar/commands.md
+++ b/docs/using-northstar/commands.md
@@ -1,5 +1,14 @@
 # Commands
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/commands
+
+{% endhint %}
+
 ## Opening the Console
 
 Commands are run on the console. To open it, press `` ` `` (the key above `TAB`).\

--- a/docs/using-northstar/direct-connect.md
+++ b/docs/using-northstar/direct-connect.md
@@ -1,5 +1,14 @@
 # Direct Connect
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/direct-connect
+
+{% endhint %}
+
 If a server is set to private and doesn't show up in the server browser, you can directly connect to it from the console by:
 
 1. [Opening the console](commands.md#opening-the-console).

--- a/docs/using-northstar/gamemodes.md
+++ b/docs/using-northstar/gamemodes.md
@@ -1,5 +1,14 @@
 # Gamemodes
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/gamemodes
+
+{% endhint %}
+
 Northstar comes included with some community made gamemodes.
 
 {% hint style="info" %}

--- a/docs/using-northstar/launch-arguments.md
+++ b/docs/using-northstar/launch-arguments.md
@@ -1,5 +1,14 @@
 # Launch arguments
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/launch-arguments
+
+{% endhint %}
+
 Here's a list of new command line arguments that Northstar introduces, they should be included in `ns_startup_args.txt` or `ns_startup_args_dedi.txt`.
 
 | Argument           | Description                                                                                        | Value                            |

--- a/docs/using-northstar/mods.md
+++ b/docs/using-northstar/mods.md
@@ -1,5 +1,14 @@
 # Mods
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/mods
+
+{% endhint %}
+
 ![Northstar Mods](https://user-images.githubusercontent.com/7439692/146625579-20586c9e-2e23-4c5d-ba56-27b6eb1ffff4.jpg)
 
 ## Pre-installed mods

--- a/docs/using-northstar/packages.md
+++ b/docs/using-northstar/packages.md
@@ -1,5 +1,14 @@
 # Packages
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/packages
+
+{% endhint %}
+
 Packages are community created mods with the [Thunderstore](https://northstar.thunderstore.io/) package structure retained used for installation via Mod Managers. They are located in the `Titanfall2\R2Northstar\packages` folder and can be accessed via the `Mods` menu at the bottom of the main menu.
 
 ## Manual installation

--- a/docs/using-northstar/progression.md
+++ b/docs/using-northstar/progression.md
@@ -1,5 +1,14 @@
 # Progression
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/progression
+
+{% endhint %}
+
 As of version `1.19.0` Northstar allows you to toggle the progression system.
 This means that you can choose whether to have everything unlocked or not.
 By default progression is disabled and all weapons and skins are unlocked.

--- a/docs/using-northstar/server-browser.md
+++ b/docs/using-northstar/server-browser.md
@@ -1,5 +1,14 @@
 # Server Browser
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/server-browser
+
+{% endhint %}
+
 ![Server Browser](https://raw.githubusercontent.com/R2Northstar/NorthstarWiki/main/docs/images/serverbrowser.png)
 
 Northstar Comes with a server browser which you can use to connect to community hosted servers. Hovering over a server name will show you what mods the server has enabled and the version of those mods. Each server can be connected to by clicking on its name. You can refresh the list of servers by clicking the `Refresh` button in the bottom corner.

--- a/docs/using-northstar/vanilla.md
+++ b/docs/using-northstar/vanilla.md
@@ -1,5 +1,14 @@
 # Playing vanilla Titanfall 2 via Northstar
 
+{% hint style="warning" %}
+The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDocs](https://docs.northstar.tf/) where this wiki has been integrated.
+
+Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
+
+The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/vanilla
+
+{% endhint %}
+
 While Northstar comes pre-packaged with mods to support community servers and custom content, some users may not want all of this.
 Northstar can also be used to load mods on vanilla more easily and with more stability than vpk modding, and can sometimes help when the game doesn't want to launch at all.
 


### PR DESCRIPTION
Adds deprecation notices to all pages as well as the main repo pointing to the new documentation.

For individual pages it also contains a link to the page on the new NorthstarDocs.