### PR TITLE
Make sure links in deprecation notices are clickable

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/./
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
 {% endhint %}
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,7 +7,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/contributing
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/contributing](https://docs.northstar.tf/Wiki/contributing)
 
 {% endhint %}
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -9,7 +9,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/](https://docs.northstar.tf/Wiki/development/)
 
 {% endhint %}
 

--- a/docs/development/contributing-code-to-northstar.md
+++ b/docs/development/contributing-code-to-northstar.md
@@ -7,7 +7,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/contributing-code-to-northstar
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/contributing-code-to-northstar](https://docs.northstar.tf/Wiki/development/contributing-code-to-northstar)
 
 {% endhint %}
 

--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/debugging/
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/debugging/](https://docs.northstar.tf/Wiki/development/debugging/)
 
 {% endhint %}
 

--- a/docs/development/debugging/visualstudio.md
+++ b/docs/development/debugging/visualstudio.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/debugging/visualstudio
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/debugging/visualstudio](https://docs.northstar.tf/Wiki/development/debugging/visualstudio)
 
 {% endhint %}
 

--- a/docs/development/debugging/x64dbg.md
+++ b/docs/development/debugging/x64dbg.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/debugging/x64dbg
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/debugging/x64dbg](https://docs.northstar.tf/Wiki/development/debugging/x64dbg)
 
 {% endhint %}
 

--- a/docs/development/northstarmasterserver/README.md
+++ b/docs/development/northstarmasterserver/README.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/northstarmasterserver/
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/northstarmasterserver/](https://docs.northstar.tf/Wiki/development/northstarmasterserver/)
 
 {% endhint %}
 

--- a/docs/development/northstarmasterserver/deploy.md
+++ b/docs/development/northstarmasterserver/deploy.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/northstarmasterserver/deploy
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/northstarmasterserver/deploy](https://docs.northstar.tf/Wiki/development/northstarmasterserver/deploy)
 
 {% endhint %}
 

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -9,7 +9,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/releases
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/releases](https://docs.northstar.tf/Wiki/development/releases)
 
 {% endhint %}
 

--- a/docs/development/repositories/README.md
+++ b/docs/development/repositories/README.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/repositories/
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/repositories/](https://docs.northstar.tf/Wiki/development/repositories/)
 
 {% endhint %}
 

--- a/docs/development/repositories/atlas.md
+++ b/docs/development/repositories/atlas.md
@@ -7,7 +7,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/repositories/atlas
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/repositories/atlas](https://docs.northstar.tf/Wiki/development/repositories/atlas)
 
 {% endhint %}
 

--- a/docs/development/repositories/northstarlauncher.md
+++ b/docs/development/repositories/northstarlauncher.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/repositories/northstarlauncher
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/repositories/northstarlauncher](https://docs.northstar.tf/Wiki/development/repositories/northstarlauncher)
 
 {% endhint %}
 

--- a/docs/development/repositories/northstarmods.md
+++ b/docs/development/repositories/northstarmods.md
@@ -7,7 +7,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/repositories/northstarmods
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/repositories/northstarmods](https://docs.northstar.tf/Wiki/development/repositories/northstarmods)
 
 {% endhint %}
 

--- a/docs/development/reviewing.md
+++ b/docs/development/reviewing.md
@@ -10,7 +10,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/reviewing
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/reviewing](https://docs.northstar.tf/Wiki/development/reviewing)
 
 {% endhint %}
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -9,7 +9,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/development/testing
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/development/testing](https://docs.northstar.tf/Wiki/development/testing)
 
 {% endhint %}
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,7 +7,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/faq
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/faq](https://docs.northstar.tf/Wiki/faq)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/basic-listen-server.md
+++ b/docs/hosting-a-server-with-northstar/basic-listen-server.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/basic-listen-server
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/basic-listen-server](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/basic-listen-server)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/dedicated-server/README.md
+++ b/docs/hosting-a-server-with-northstar/dedicated-server/README.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/dedicated-server/best-practices.md
+++ b/docs/hosting-a-server-with-northstar/dedicated-server/best-practices.md
@@ -7,7 +7,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/best-practices
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/best-practices](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/best-practices)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/dedicated-server/hosting-on-linux.md
+++ b/docs/hosting-a-server-with-northstar/dedicated-server/hosting-on-linux.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/hosting-on-linux
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/hosting-on-linux](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/hosting-on-linux)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/dedicated-server/hosting-on-windows.md
+++ b/docs/hosting-a-server-with-northstar/dedicated-server/hosting-on-windows.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/hosting-on-windows
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/hosting-on-windows](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/dedicated-server/hosting-on-windows)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/getting-started.md
+++ b/docs/hosting-a-server-with-northstar/getting-started.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/getting-started
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/getting-started](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/getting-started)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/local-only-server.md
+++ b/docs/hosting-a-server-with-northstar/local-only-server.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/local-only-server
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/local-only-server](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/local-only-server)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/server-settings/README.md
+++ b/docs/hosting-a-server-with-northstar/server-settings/README.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/server-settings/banlist.md
+++ b/docs/hosting-a-server-with-northstar/server-settings/banlist.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/banlist
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/banlist](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/banlist)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/server-settings/convars.md
+++ b/docs/hosting-a-server-with-northstar/server-settings/convars.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/convars
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/convars](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/convars)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/server-settings/file-names.md
+++ b/docs/hosting-a-server-with-northstar/server-settings/file-names.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/file-names
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/file-names](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/file-names)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/server-settings/playlistvar.md
+++ b/docs/hosting-a-server-with-northstar/server-settings/playlistvar.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/playlistvar
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/playlistvar](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/playlistvar)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/server-settings/startup-args.md
+++ b/docs/hosting-a-server-with-northstar/server-settings/startup-args.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/startup-args
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/startup-args](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/server-settings/startup-args)
 
 {% endhint %}
 

--- a/docs/hosting-a-server-with-northstar/troubleshooting.md
+++ b/docs/hosting-a-server-with-northstar/troubleshooting.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/troubleshooting
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/troubleshooting](https://docs.northstar.tf/Wiki/hosting-a-server-with-northstar/troubleshooting)
 
 {% endhint %}
 

--- a/docs/installing-northstar/basic-setup.md
+++ b/docs/installing-northstar/basic-setup.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/basic-setup
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/installing-northstar/basic-setup](https://docs.northstar.tf/Wiki/installing-northstar/basic-setup)
 
 {% endhint %}
 

--- a/docs/installing-northstar/manual-installation.md
+++ b/docs/installing-northstar/manual-installation.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/manual-installation
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/installing-northstar/manual-installation](https://docs.northstar.tf/Wiki/installing-northstar/manual-installation)
 
 {% endhint %}
 

--- a/docs/installing-northstar/northstar-installers/README.md
+++ b/docs/installing-northstar/northstar-installers/README.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/](https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/)
 
 {% endhint %}
 

--- a/docs/installing-northstar/northstar-installers/flightcore-guide.md
+++ b/docs/installing-northstar/northstar-installers/flightcore-guide.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/flightcore-guide
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/flightcore-guide](https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/flightcore-guide)
 
 {% endhint %}
 

--- a/docs/installing-northstar/northstar-installers/viper-guide.md
+++ b/docs/installing-northstar/northstar-installers/viper-guide.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/viper-guide
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/viper-guide](https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/viper-guide)
 
 {% endhint %}
 

--- a/docs/installing-northstar/northstar-installers/vtol-guide.md
+++ b/docs/installing-northstar/northstar-installers/vtol-guide.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/vtol-guide
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/vtol-guide](https://docs.northstar.tf/Wiki/installing-northstar/northstar-installers/vtol-guide)
 
 {% endhint %}
 

--- a/docs/installing-northstar/troubleshooting.md
+++ b/docs/installing-northstar/troubleshooting.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/installing-northstar/troubleshooting
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/installing-northstar/troubleshooting](https://docs.northstar.tf/Wiki/installing-northstar/troubleshooting)
 
 {% endhint %}
 

--- a/docs/modding/README.md
+++ b/docs/modding/README.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/modding/
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/modding/](https://docs.northstar.tf/Wiki/modding/)
 
 {% endhint %}
 

--- a/docs/other/credits.md
+++ b/docs/other/credits.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/other/credits
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/other/credits](https://docs.northstar.tf/Wiki/other/credits)
 
 {% endhint %}
 

--- a/docs/other/helping.md
+++ b/docs/other/helping.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/other/helping
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/other/helping](https://docs.northstar.tf/Wiki/other/helping)
 
 {% endhint %}
 

--- a/docs/other/moderation/README.md
+++ b/docs/other/moderation/README.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/other/moderation/
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/other/moderation/](https://docs.northstar.tf/Wiki/other/moderation/)
 
 {% endhint %}
 

--- a/docs/other/moderation/rules.md
+++ b/docs/other/moderation/rules.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/other/moderation/rules
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/other/moderation/rules](https://docs.northstar.tf/Wiki/other/moderation/rules)
 
 {% endhint %}
 

--- a/docs/steamdeck-and-linux/README.md
+++ b/docs/steamdeck-and-linux/README.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/steamdeck-and-linux/
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/steamdeck-and-linux/](https://docs.northstar.tf/Wiki/steamdeck-and-linux/)
 
 {% endhint %}
 

--- a/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
+++ b/docs/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/steamdeck-and-linux/installing-on-steamdeck-and-linux
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/steamdeck-and-linux/installing-on-steamdeck-and-linux](https://docs.northstar.tf/Wiki/steamdeck-and-linux/installing-on-steamdeck-and-linux)
 
 {% endhint %}
 

--- a/docs/steamdeck-and-linux/linux-troubleshooting.md
+++ b/docs/steamdeck-and-linux/linux-troubleshooting.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/steamdeck-and-linux/linux-troubleshooting
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/steamdeck-and-linux/linux-troubleshooting](https://docs.northstar.tf/Wiki/steamdeck-and-linux/linux-troubleshooting)
 
 {% endhint %}
 

--- a/docs/using-northstar/README.md
+++ b/docs/using-northstar/README.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/using-northstar/](https://docs.northstar.tf/Wiki/using-northstar/)
 
 {% endhint %}
 

--- a/docs/using-northstar/advanced.md
+++ b/docs/using-northstar/advanced.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/advanced
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/using-northstar/advanced](https://docs.northstar.tf/Wiki/using-northstar/advanced)
 
 {% endhint %}
 

--- a/docs/using-northstar/commands.md
+++ b/docs/using-northstar/commands.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/commands
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/using-northstar/commands](https://docs.northstar.tf/Wiki/using-northstar/commands)
 
 {% endhint %}
 

--- a/docs/using-northstar/direct-connect.md
+++ b/docs/using-northstar/direct-connect.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/direct-connect
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/using-northstar/direct-connect](https://docs.northstar.tf/Wiki/using-northstar/direct-connect)
 
 {% endhint %}
 

--- a/docs/using-northstar/gamemodes.md
+++ b/docs/using-northstar/gamemodes.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/gamemodes
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/using-northstar/gamemodes](https://docs.northstar.tf/Wiki/using-northstar/gamemodes)
 
 {% endhint %}
 

--- a/docs/using-northstar/launch-arguments.md
+++ b/docs/using-northstar/launch-arguments.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/launch-arguments
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/using-northstar/launch-arguments](https://docs.northstar.tf/Wiki/using-northstar/launch-arguments)
 
 {% endhint %}
 

--- a/docs/using-northstar/mods.md
+++ b/docs/using-northstar/mods.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/mods
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/using-northstar/mods](https://docs.northstar.tf/Wiki/using-northstar/mods)
 
 {% endhint %}
 

--- a/docs/using-northstar/packages.md
+++ b/docs/using-northstar/packages.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/packages
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/using-northstar/packages](https://docs.northstar.tf/Wiki/using-northstar/packages)
 
 {% endhint %}
 

--- a/docs/using-northstar/progression.md
+++ b/docs/using-northstar/progression.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/progression
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/using-northstar/progression](https://docs.northstar.tf/Wiki/using-northstar/progression)
 
 {% endhint %}
 

--- a/docs/using-northstar/server-browser.md
+++ b/docs/using-northstar/server-browser.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/server-browser
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/using-northstar/server-browser](https://docs.northstar.tf/Wiki/using-northstar/server-browser)
 
 {% endhint %}
 

--- a/docs/using-northstar/vanilla.md
+++ b/docs/using-northstar/vanilla.md
@@ -5,7 +5,7 @@ The GitBook based NorthstarWiki has been replaced in favour of the [NorthstarDoc
 
 Check it out here: [https://docs.northstar.tf/Wiki/](https://docs.northstar.tf/Wiki/)
 
-The same page on the new wiki should be located here: https://docs.northstar.tf/Wiki/using-northstar/vanilla
+The same page on the new wiki should be located here: [https://docs.northstar.tf/Wiki/using-northstar/vanilla](https://docs.northstar.tf/Wiki/using-northstar/vanilla)
 
 {% endhint %}
 


### PR DESCRIPTION
They need to be formatted as Markdown links to actually be clickable.